### PR TITLE
Set hopLimit to the config of the device

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -889,7 +889,7 @@ def initParser():
         "--ch-set", help=("Set a channel parameter. To see channel settings available:'--ch-set all all --ch-index 0'. "
                           "Can set the 'psk' using this command. To disable encryption on primary channel:'--ch-set psk none --ch-index 0'. "
                           "To set encryption with a new random key on second channel:'--ch-set psk random --ch-index 1'. "
-                          "To set encryption back to the default:'--ch-set default --ch-index 0'. To set encryption with your "
+                          "To set encryption back to the default:'--ch-set psk default --ch-index 0'. To set encryption with your "
                           "own key: '--ch-set psk 0x1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b --ch-index 0'."),
                           nargs=2, action='append')
 


### PR DESCRIPTION
Fixes #405. Since the hopLimit was never set to anything else than the default of 3, it will now only set it in _sendPacket() and there it will use what is set in the loraConfig of the device. 

Also a minor fix for the help message of --ch-set. 