### PR TITLE
Get and set methods for remote node using one admin message

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -406,6 +406,7 @@ def onConnected(interface):
         # handle settings
         if args.set:
             closeNow = True
+            waitForAckNak = True
             node = interface.getNode(args.dest, False)
 
             # Handle the int/float/bool arguments

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -648,6 +648,9 @@ def onConnected(interface):
 
         if args.nodes:
             closeNow = True
+            if args.dest != BROADCAST_ADDR:
+                print("Showing node list of a remote node is not supported.")
+                return
             interface.showNodes()
 
         if args.qr:

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -65,6 +65,7 @@ def getPref(interface, dest, comp_name):
     logging.debug(f'snake_name:{snake_name} camel_name:{camel_name}')
     logging.debug(f'use camel:{Globals.getInstance().get_camel_case()}')
 
+    # First validate the input by looking at config of connected node
     localConfig = interface.getNode(BROADCAST_ADDR).localConfig
     moduleConfig = interface.getNode(BROADCAST_ADDR).moduleConfig
     found = False
@@ -103,7 +104,7 @@ def getPref(interface, dest, comp_name):
             print(f"{str(config_type.name)}: {str(config_values)}")
             logging.debug(f"{str(config_type.name)}: {str(config_values)}")
     else: 
-        # Always request full config for remote node
+        # Always show full config for remote node
         interface.getNode(dest, False).requestConfig(config_type)
         
     return True

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -170,18 +170,18 @@ class MeshInterface:
         return table
 
 
-    def getNode(self, nodeId, requestConfig=True):
+    def getNode(self, nodeId, requestChannels=True):
         """Return a node object which contains device settings and channel info"""
         if nodeId in (LOCAL_ADDR, BROADCAST_ADDR):
             return self.localNode
         else:
             n = meshtastic.node.Node(self, nodeId)
             # Only request device settings and channel info when necessary
-            if requestConfig:
-                logging.debug("About to requestConfig")
-                n.requestConfig()
+            if requestChannels:
+                logging.debug("About to requestChannels")
+                n.requestChannels()
                 if not n.waitForConfig():
-                    our_exit("Error: Timed out waiting for node config")
+                    our_exit("Error: Timed out waiting for channels")
             return n
 
     def sendText(self, text: AnyStr,
@@ -522,7 +522,7 @@ class MeshInterface:
         Done with initial config messages, now send regular MeshPackets
         to ask for settings and channels
         """
-        self.localNode.requestConfig()
+        self.localNode.requestChannels()
 
     def _handleFromRadio(self, fromRadioBytes):
         """

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -78,10 +78,13 @@ class Node:
                 self.iface._acknowledgment.receivedNak = True
         else:
             self.iface._acknowledgment.receivedAck = True
+            print("")
             if "getConfigResponse" in p["decoded"]["admin"]:
-                print("Config is as follows:", p["decoded"]["admin"]['getConfigResponse'])
+                prefs = stripnl(p["decoded"]["admin"]["getConfigResponse"])
+                print(f"Preferences: {prefs}\n")
             else:
-                print("Module Config is as follows:", p["decoded"]["admin"]['getModuleConfigResponse'])
+                prefs = stripnl(p["decoded"]["admin"]["getModuleConfigResponse"])
+                print(f"Module preferences: {prefs}\n")
 
     def requestConfig(self, configType):
         print("Requesting config from remote node (this can take a while).")


### PR DESCRIPTION
Now the commands `--get` and `--set` work for remote nodes by using only one admin message per field and it doesn’t request all channels. When setting, it first requests the current config of the field, then sends an updated admin message, after which it waits for an ACK from the remote node.

This partly fixes #423. When trying `--info` for a remote node, it prints that you need to use `--get` with a specific field. Also, it prints that `--nodes` for a remote node is not supported (currently it was showing the list of the connected node).