### PR TITLE
Fix remote_hardware configuration

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -615,6 +615,8 @@ class MeshInterface:
                 self.localNode.moduleConfig.telemetry.CopyFrom(fromRadio.moduleConfig.telemetry)
             elif fromRadio.moduleConfig.HasField("canned_message"):
                 self.localNode.moduleConfig.canned_message.CopyFrom(fromRadio.moduleConfig.canned_message)
+            elif fromRadio.moduleConfig.HasField("remote_hardware"):
+                self.localNode.moduleConfig.remote_hardware.CopyFrom(fromRadio.moduleConfig.remote_hardware)
 
         else:
             logging.debug("Unexpected FromRadio payload")

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -83,19 +83,19 @@ class Node:
             if "getConfigResponse" in adminMessage:
                 resp = adminMessage["getConfigResponse"]
                 field = list(resp.keys())[0]
-                config_type = self.localConfig.DESCRIPTOR.fields_by_name.get(field)
+                config_type = self.localConfig.DESCRIPTOR.fields_by_name.get(camel_to_snake(field))
                 config_values = getattr(self.localConfig, config_type.name)
             elif "getModuleConfigResponse" in adminMessage:
                 resp = adminMessage["getModuleConfigResponse"]
                 field = list(resp.keys())[0]
-                config_type = self.moduleConfig.DESCRIPTOR.fields_by_name.get(field)
+                config_type = self.moduleConfig.DESCRIPTOR.fields_by_name.get(camel_to_snake(field))
                 config_values = getattr(self.moduleConfig, config_type.name)
             else: 
                 print("Did not receive a valid response. Make sure to have a shared channel named 'admin'.")
                 return
             for key, value in resp[field].items():
                 setattr(config_values, camel_to_snake(key), value)
-            print(f"{str(field)}:\n{str(config_values)}")
+            print(f"{str(camel_to_snake(field))}:\n{str(config_values)}")
 
     def requestConfig(self, configType):
         if self == self.iface.localNode:
@@ -233,7 +233,14 @@ class Node:
             p = admin_pb2.AdminMessage()
             p.set_module_config.audio.CopyFrom(self.moduleConfig.audio)
             self._sendAdmin(p)
-            logging.debug("Wrote module: audo")
+            logging.debug("Wrote module: audio")
+            time.sleep(0.3)
+
+        if self.moduleConfig.remote_hardware:
+            p = admin_pb2.AdminMessage()
+            p.set_module_config.remote_hardware.CopyFrom(self.moduleConfig.remote_hardware)
+            self._sendAdmin(p)
+            logging.debug("Wrote module: remote_hardware")
             time.sleep(0.3)
 
     def writeConfig(self, config_name):
@@ -273,6 +280,8 @@ class Node:
             p.set_module_config.canned_message.CopyFrom(self.moduleConfig.canned_message)
         elif config_name == 'audio':
             p.set_module_config.audio.CopyFrom(self.moduleConfig.audio)
+        elif config_name == 'remote_hardware':
+            p.set_module_config.remote_hardware.CopyFrom(self.moduleConfig.remote_hardware)
         else:
             our_exit(f"Error: No valid config with name {config_name}")
         

--- a/meshtastic/tests/test_remote_hardware.py
+++ b/meshtastic/tests/test_remote_hardware.py
@@ -23,7 +23,7 @@ def test_RemoteHardwareClient():
 def test_onGPIOreceive(capsys):
     """Test onGPIOreceive"""
     iface = MagicMock(autospec=SerialInterface)
-    packet = {'decoded': {'remotehw': {'typ': 'foo', 'gpioValue': '4096' }}}
+    packet = {'decoded': {'remotehw': {'type': 'foo', 'gpioValue': '4096' }}}
     onGPIOreceive(packet, iface)
     out, err = capsys.readouterr()
     assert re.search(r'Received RemoteHardware', out)


### PR DESCRIPTION
This is a fix for #430 [Bug]: remote_hardware configuration errors and exceptions.

Test results:

1. local get
```
$ meshtastic --get remote_hardware.enabled
Connected to radio
remote_hardware.enabled: True
Completed getting preferences
```

2. remote set
```
$ meshtastic --dest \!fa5a06f8 --set remote_hardware.enabled false
Connected to radio
Requesting current config from remote node (this can take a while).

remote_hardware:
enabled: true

Set remote_hardware.enabled to false
Writing modified preferences to device
Waiting for an acknowledgment from remote node (this could take a while)
Received an ACK.
```

3. export config 
```
$ meshtastic --export-config
# start of Meshtastic configure yaml
channel_url: https://meshtastic.org/e/#CioSINBfUzPyF761lXVIf_bgE09Sy4PAD3WOxpyKYKKRIgXEC7ENxVYRc3p1J3BWwpfEjm8jMrEU4IF_rasdfhkljfgasdgdshgfdjLhgqZY6QaBWFkbWluCQQ8ti0n3yxDNSWFg45XdkT8NIImW6GgVhbG11YwopEiBJdEEi9Fz_Bdd2Fhefdsgdsfghl40SBwbJcZRFIBqWrr3VnJLTCNhoFSGVsZmEKDxIBARoKTE9OR0ZBU1QtSQooEiBu4RXJzC-O0KtcVvGuEfYNEsDJ3VACkY0AYsdfgsdsgsd5jXwXHUshoEZ3BpbxIOCAE4A0aAE
config:
  bluetooth:
    enabled: true
    fixedPin: 123456
  device:
    nodeInfoBroadcastSecs: 10800
    rebroadcastMode: LOCAL_ONLY
    role: ROUTER_CLIENT
    serialEnabled: true
  display:
    autoScreenCarouselSecs: 10
    screenOnSecs: 10
  lora:
    hopLimit: 3
    overrideDutyCycle: true
    region: EU_868
    sx126xRxBoostedGain: true
    txEnabled: true
    txPower: 27
    usePreset: true
  network:
    ntpServer: 0.pool.ntp.org
  position:
    gpsAttemptTime: 900
    gpsUpdateInterval: 120
    positionBroadcastSecs: 900
    positionBroadcastSmartEnabled: true
    positionFlags: 3
    rxGpio: 34
    txGpio: 12
  power:
    lsSecs: 300
    meshSdsTimeoutSecs: 7200
    minWakeSecs: 10
    sdsSecs: 4294967295
    waitBluetoothSecs: 60
module_config:
  mqtt:
    address: mqtt.meshtastic.org
    password: large4cats
    username: meshdev
  rangeTest:
    sender: 60
  remoteHardware:
    enabled: true
  telemetry:
    airQualityInterval: 900
    deviceUpdateInterval: 900
    environmentUpdateInterval: 900
owner: Meshtastic 06bc
owner_short: 06bc
```

4. import config
```
$ python -m meshtastic --port /dev/ttyACM0 --configure export
Connected to radio
INFO file:node.py beginSettingsTransaction line:604 Telling open a transaction to edit settings
Setting device owner to Meshtastic 06bc
Setting device owner short to 06bc
Setting channel url to https://meshtastic.org/e/#CioSINBfUzPyF761lXVIf_bgE09Sy4PAD3WOxpyKYKKRIgXEC7ENxVYRc3p1J3BWwpfEjm8jMrEU4IF_rasdfhkljfgasdgdshgfdjLhgqZY6QaBWFkbWluCQQ8ti0n3yxDNSWFg45XdkT8NIImW6GgVhbG11YwopEiBJdEEi9Fz_Bdd2Fhefdsgdsfghl40SBwbJcZRFIBqWrr3VnJLTCNhoFSGVsZmEKDxIBARoKTE9OR0ZBU1QtSQooEiBu4RXJzC-O0KtcVvGuEfYNEsDJ3VACkY0AYsdfgsdsgsd5jXwXHUshoEZ3BpbxIOCAE4A0aAE
Set bluetooth.enabled to True
Set bluetooth.fixed_pin to 123456
Set device.node_info_broadcast_secs to 10800
Set device.rebroadcast_mode to LOCAL_ONLY
Set device.role to ROUTER_CLIENT
Set device.serial_enabled to True
Set display.auto_screen_carousel_secs to 10
Set display.screen_on_secs to 10
Set lora.hop_limit to 3
Set lora.override_duty_cycle to True
Set lora.region to EU_868
Set lora.sx126x_rx_boosted_gain to True
Set lora.tx_enabled to True
Set lora.tx_power to 27
Set lora.use_preset to True
Set network.ntp_server to 0.pool.ntp.org
Set position.gps_attempt_time to 900
Set position.gps_update_interval to 120
Set position.position_broadcast_secs to 900
Set position.position_broadcast_smart_enabled to True
Set position.position_flags to 3
Set position.rx_gpio to 34
Set position.tx_gpio to 12
Set power.ls_secs to 300
Set power.mesh_sds_timeout_secs to 7200
Set power.min_wake_secs to 10
Set power.sds_secs to 4294967295
Set power.wait_bluetooth_secs to 60
Set mqtt.address to mqtt.meshtastic.org
Set mqtt.password to large4cats
Set mqtt.username to meshdev
Set range_test.sender to 60
Set remote_hardware.enabled to True
Set telemetry.air_quality_interval to 900
Set telemetry.device_update_interval to 900
Set telemetry.environment_update_interval to 900
INFO file:node.py commitSettingsTransaction line:617 Telling node to commit open transaction for editing settings
Writing modified configuration to device
```


