### PR TITLE
Check most current meshtastic version

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -633,6 +633,10 @@ def onConnected(interface):
                 interface.getNode(args.dest).showInfo()
                 closeNow = True
                 print("")
+                pypi_version = meshtastic.util.check_if_newer_version()
+                if pypi_version:
+                    print(f'*** A newer version v{pypi_version} is available!'
+                          ' Consider running "pip install --upgrade meshtastic" ***\n')
             else:
                 print("Showing info of remote node is not supported.")
                 print("Use the '--get' command for a specific configuration (e.g. 'lora') instead.")

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -3,7 +3,6 @@
 import sys
 import random
 import time
-import json
 import logging
 from typing import AnyStr
 import threading
@@ -80,8 +79,8 @@ class MeshInterface:
         myinfo = ''
         if self.myInfo:
             myinfo = f"\nMy info: {stripnl(MessageToJson(self.myInfo))}"
-        mesh = "\n\nNodes in mesh: "
-        nodes = {}
+        mesh = "\nNodes in mesh:"
+        nodes = ""
         if self.nodes:
             for n in self.nodes.values():
                 # when the TBeam is first booted, it sometimes shows the raw data
@@ -96,11 +95,8 @@ class MeshInterface:
                     addr = convert_mac_addr(val)
                     n2['user']['macaddr'] = addr
 
-                # use id as dictionary key for correct json format in list of nodes
-                nodeid = n2['user']['id']
-                n2['user'].pop('id')
-                nodes[nodeid] = n2
-        infos = owner + myinfo + mesh + json.dumps(nodes)
+                nodes = nodes + f"  {stripnl(n2)}"
+        infos = owner + myinfo + mesh + nodes
         print(infos)
         return infos
 

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -3,6 +3,7 @@
 import sys
 import random
 import time
+import json
 import logging
 from typing import AnyStr
 import threading
@@ -79,8 +80,8 @@ class MeshInterface:
         myinfo = ''
         if self.myInfo:
             myinfo = f"\nMy info: {stripnl(MessageToJson(self.myInfo))}"
-        mesh = "\nNodes in mesh:"
-        nodes = ""
+        mesh = "\n\nNodes in mesh: "
+        nodes = {}
         if self.nodes:
             for n in self.nodes.values():
                 # when the TBeam is first booted, it sometimes shows the raw data
@@ -95,8 +96,11 @@ class MeshInterface:
                     addr = convert_mac_addr(val)
                     n2['user']['macaddr'] = addr
 
-                nodes = nodes + f"  {stripnl(n2)}"
-        infos = owner + myinfo + mesh + nodes
+                # use id as dictionary key for correct json format in list of nodes
+                nodeid = n2['user']['id']
+                n2['user'].pop('id')
+                nodes[nodeid] = n2
+        infos = owner + myinfo + mesh + json.dumps(nodes)
         print(infos)
         return infos
 

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -14,6 +14,8 @@ import subprocess
 import serial
 import serial.tools.list_ports
 import pkg_resources
+import requests
+
 
 from meshtastic.supported_device import supported_devices
 
@@ -241,7 +243,11 @@ def support_info():
     print(f'   Encoding (stdin): {sys.stdin.encoding}')
     print(f'   Encoding (stdout): {sys.stdout.encoding}')
     the_version = pkg_resources.get_distribution("meshtastic").version
-    print(f' meshtastic: v{the_version}')
+    pypi_version = check_if_newer_version()
+    if pypi_version:
+        print(f' meshtastic: v{the_version} (*** newer version v{pypi_version} available ***)')
+    else:
+        print(f' meshtastic: v{the_version}')
     print(f' Executable: {sys.argv[0]}')
     print(f' Python: {platform.python_version()} {platform.python_implementation()} {platform.python_compiler()}')
     print('')
@@ -545,3 +551,19 @@ def detect_windows_port(sd):
                 #print(f'x:{x}')
                 ports.add(f'COM{x}')
     return ports
+
+
+def check_if_newer_version():
+    """Check pip to see if we are running the latest version."""
+    pypi_version = None
+    try:
+        url = "https://pypi.org/pypi/meshtastic/json"
+        data = requests.get(url).json()
+        pypi_version = data["info"]["version"]
+    except Exception as e:
+        #print(f"could not get version from pypi e:{e}")
+        pass
+    act_version = pkg_resources.get_distribution("meshtastic").version
+    if pypi_version and pkg_resources.parse_version(pypi_version) <= pkg_resources.parse_version(act_version):
+        return None
+    return pypi_version

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pyqrcode
 tabulate
 timeago
 webencodings
+requests
 pyparsing
 twine
 autopep8

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     packages=["meshtastic"],
     include_package_data=True,
-    install_requires=["pyserial>=3.4", "protobuf>=3.13.0",
+    install_requires=["pyserial>=3.4", "protobuf>=3.13.0", "requests>=2.25.0",
                       "pypubsub>=4.0.3", "dotmap>=1.3.14", "pexpect>=4.6.0", "pyqrcode>=1.2.1",
                       "tabulate>=0.8.9", "timeago>=1.0.15", "pyyaml",
                       "pygatt>=4.0.5 ; platform_system=='Linux'"],


### PR DESCRIPTION
This is a solution for #274 Let user know if they are not running the most current version of the cli.

It affects the --info and --support command:

```
$ meshtastic --info

[...]

*** A newer version v2.1.4 is available! Consider running "pip install --upgrade meshtastic" ***

$ meshtastic --support

If having issues with meshtastic cli or python library
or wish to make feature requests, visit:
https://github.com/meshtastic/python/issues
When adding an issue, be sure to include the following info:
 System: Linux
   Platform: Linux-6.2.7-200.fc37.x86_64-x86_64-with-glibc2.36
   Release: 6.2.7-200.fc37.x86_64
   Machine: x86_64
   Encoding (stdin): utf-8
   Encoding (stdout): utf-8
 meshtastic: v2.1.3 (*** newer version v2.1.4 available ***)
 Executable: /home/manuel/Documents/PlatformIO/Projects/python-fork/meshtastic/__main__.py
 Python: 3.11.2 CPython GCC 12.2.1 20221121 (Red Hat 12.2.1-4)

Please add the output from the command: meshtastic --info

```