### PR TITLE
Update Supported Device List

### DIFF
--- a/meshtastic/supported_device.py
+++ b/meshtastic/supported_device.py
@@ -275,6 +275,7 @@ supported_devices = [
     heltec_v2_0,
     heltec_v2_1,
     heltec_v3,
+    heltec_wsl_v3,
     meshtastic_diy_v1,
     techo_1,
     rak4631_5005,


### PR DESCRIPTION
Not sure if this matters or not but I noticed the list of devices in supported_device.py was seriously outdated. I've done my best to format as required based on how others are and I think I've got it mostly right. The usb vid/pid for the t3s3 and station g1 and nano g1 explorer devices I'm not sure if are accurate or not as I don't have them. Most of the devices in a family seem to share these so I'm assuming that's the case here but maybe someone with them can double check? Leaving this as a draft for input for now as it's kind of out of my wheelbase. 