### PR TITLE
Fix various source comment typos

### DIFF
--- a/bin/regen-docs.sh
+++ b/bin/regen-docs.sh
@@ -1,4 +1,4 @@
 # Note: Docs are generated from this command below, albeit from Vercel.
-# The docs/ dir is not used and is no longer commited.
+# The docs/ dir is not used and is no longer committed.
 # see sachaw if you have questions
 pdoc3 --html -f --output-dir docs meshtastic

--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -98,7 +98,7 @@ LOCAL_ADDR = "^local"
 """A special ID that means the local node"""
 
 BROADCAST_NUM = 0xFFFFFFFF
-"""if using 8 bit nodenums this will be shortend on the target"""
+"""if using 8 bit nodenums this will be shortened on the target"""
 
 BROADCAST_ADDR = "^all"
 """A special ID that means broadcast"""
@@ -172,7 +172,7 @@ def _onNodeInfoReceive(iface, asDict):
             # update node DB as needed
             n = iface._getOrCreateByNum(asDict["from"])
             n["user"] = p
-            # We now have a node ID, make sure it is uptodate in that table
+            # We now have a node ID, make sure it is up-to-date in that table
             iface.nodes[p["id"]] = n
             _receiveInfoUpdate(iface, asDict)
 

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -130,7 +130,7 @@ class MeshInterface:
         """Show table summary of nodes in mesh"""
 
         def formatFloat(value, precision=2, unit=""):
-            """Format a float value with precsion."""
+            """Format a float value with precision."""
             return f"{value:.{precision}f}{unit}" if value else None
 
         def getLH(ts):
@@ -843,7 +843,7 @@ class MeshInterface:
         if nodeNum in self.nodesByNum:
             return self.nodesByNum[nodeNum]
         else:
-            n = {"num": nodeNum}  # Create a minimial node db entry
+            n = {"num": nodeNum}  # Create a minimal node db entry
             self.nodesByNum[nodeNum] = n
             return n
 

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -221,7 +221,7 @@ class Node:
         return ch
 
     def deleteChannel(self, channelIndex):
-        """Delete the specifed channelIndex and shift other channels up"""
+        """Delete the specified channelIndex and shift other channels up"""
         ch = self.channels[channelIndex]
         if ch.role not in (
             channel_pb2.Channel.Role.SECONDARY,
@@ -654,7 +654,7 @@ class Node:
             return
 
         c = p["decoded"]["admin"]["raw"].get_device_metadata_response
-        self._timeout.reset()  # We made foreward progress
+        self._timeout.reset()  # We made forward progress
         logging.debug(f"Received metadata {stripnl(c)}")
         print(f"\nfirmware_version: {c.firmware_version}")
         print(f"device_state_version: {c.device_state_version}")
@@ -681,7 +681,7 @@ class Node:
 
         c = p["decoded"]["admin"]["raw"].get_channel_response
         self.partialChannels.append(c)
-        self._timeout.reset()  # We made foreward progress
+        self._timeout.reset()  # We made forward progress
         logging.debug(f"Received channel {stripnl(c)}")
         index = c.index
 

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -60,7 +60,7 @@ class StreamInterface(MeshInterface):
 
         # Send some bogus UART characters to force a sleeping device to wake, and
         # if the reading statemachine was parsing a bad packet make sure
-        # we write enought start bytes to force it to resync (we don't use START1
+        # we write enough start bytes to force it to resync (we don't use START1
         # because we want to ensure it is looking for START1)
         p = bytearray([START2] * 32)
         self._writeBytes(p)

--- a/meshtastic/tests/test_smoke1.py
+++ b/meshtastic/tests/test_smoke1.py
@@ -6,7 +6,7 @@ import subprocess
 import time
 
 # Do not like using hard coded sleeps, but it probably makes
-# sense to pause for the radio at apprpriate times
+# sense to pause for the radio at appropriate times
 import pytest
 
 from ..util import findPorts

--- a/meshtastic/tests/test_smokevirt.py
+++ b/meshtastic/tests/test_smokevirt.py
@@ -14,7 +14,7 @@ import subprocess
 import time
 
 # Do not like using hard coded sleeps, but it probably makes
-# sense to pause for the radio at apprpriate times
+# sense to pause for the radio at appropriate times
 import pytest
 
 from ..util import findPorts


### PR DESCRIPTION
Found via `codespell -q 3`