### PR TITLE
Exit with an error code on failure

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -779,6 +779,7 @@ def onConnected(interface):
     except Exception as ex:
         print(f"Aborting due to: {ex}")
         interface.close()  # close the connection now, so that our app exits
+        sys.exit(1)
 
 
 def printConfig(config):


### PR DESCRIPTION
This makes it easier to use the meshtastic cli in simple scripts that can retry after failure.