### PR TITLE
Add `request-telemetry` option

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -412,6 +412,13 @@ def onConnected(interface):
             print(f"Sending traceroute request to {dest} (this could take a while)")
             interface.sendTraceRoute(dest, hopLimit)
 
+        if args.request_telemetry:
+            if args.dest == BROADCAST_ADDR:
+                meshtastic.util.our_exit("Warning: Must use a destination node ID.")
+            else:
+                print(f"Sending telemetry request to {args.dest} (this could take a while)")
+                interface.sendTelemetry(destinationId=args.dest, wantResponse=True)
+
         if args.gpio_wrb or args.gpio_rd or args.gpio_watch:
             if args.dest == BROADCAST_ADDR:
                 meshtastic.util.our_exit("Warning: Must use a destination node ID.")
@@ -1186,6 +1193,14 @@ def initParser():
         "You need pass the destination ID as argument, like "
         "this: '--traceroute !ba4bf9d0' "
         "Only nodes that have the encryption key can be traced.",
+    )
+
+    parser.add_argument(
+        "--request-telemetry", 
+        help="Request telemetry from a node."
+        "You need pass the destination ID as argument with '--dest'."
+        "For repeaters, the nodeNum is required.",
+        action="store_true", 
     )
 
     parser.add_argument(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1197,8 +1197,8 @@ def initParser():
 
     parser.add_argument(
         "--request-telemetry", 
-        help="Request telemetry from a node."
-        "You need pass the destination ID as argument with '--dest'."
+        help="Request telemetry from a node. "
+        "You need pass the destination ID as argument with '--dest'. "
         "For repeaters, the nodeNum is required.",
         action="store_true", 
     )

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -447,7 +447,8 @@ class MeshInterface:
             wantResponse=wantResponse,
             onResponse=onResponse,
         )
-        self.waitForTelemetry()
+        if wantResponse:
+            self.waitForTelemetry()
 
     def onResponseTelemetry(self, p):
         """on response for telemetry"""

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -192,7 +192,16 @@ class Timeout:
                 return True
             time.sleep(self.sleepInterval)
         return False
-
+    
+    def waitForTelemetry(self, acknowledgment):
+        """Block until telemetry response is received. Returns True if telemetry response has been received."""
+        self.reset()
+        while time.time() < self.expireTime:
+            if getattr(acknowledgment, "receivedTelemetry", None):
+                acknowledgment.reset()
+                return True
+            time.sleep(self.sleepInterval)
+        return False
 
 class Acknowledgment:
     "A class that records which type of acknowledgment was just received, if any."
@@ -203,6 +212,7 @@ class Acknowledgment:
         self.receivedNak = False
         self.receivedImplAck = False
         self.receivedTraceRoute = False
+        self.receivedTelemetry = False
 
     def reset(self):
         """reset"""
@@ -210,6 +220,7 @@ class Acknowledgment:
         self.receivedNak = False
         self.receivedImplAck = False
         self.receivedTraceRoute = False
+        self.receivedTelemetry = False
 
 
 class DeferredExecution:


### PR DESCRIPTION
Sends the telemetry of the connected node to the destination node specified with `--dest` and asks for a response. 