### PR TITLE
use default subnet set by class init

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -771,7 +771,7 @@ def onConnected(interface):
             if interface.noProto:
                 logging.warning(f"Not starting Tunnel - disabled by noProto")
             else:
-                tunnel.Tunnel(interface, subnet=args.tunnel_net)
+                tunnel.Tunnel(interface, subnet=args.tunnel_net) if args.tunnel_net else tunnel.Tunnel(interface)
 
         if args.ack or (args.dest != BROADCAST_ADDR and waitForAckNak):
             print(

--- a/meshtastic/tunnel.py
+++ b/meshtastic/tunnel.py
@@ -49,6 +49,12 @@ class Tunnel:
         if not iface:
             raise Exception("Tunnel() must have a interface")
 
+        if not subnet:
+            raise Exception("Tunnel() must have a subnet")
+
+        if not netmask:
+            raise Exception("Tunnel() must have a netmask")
+
         self.iface = iface
         self.subnetPrefix = subnet
 


### PR DESCRIPTION
Fixes issues as mentioned here
- https://github.com/meshtastic/python/issues/261#issuecomment-1036854496
- https://github.com/meshtastic/python/issues/410
- https://github.com/meshtastic/python/issues/468

My change essentially just checks to see if that `args.tunnel_net` is set before attempting to use it. This will allow for the Tunnel class __init__() method to use it's default subnet without being overwritten by a None value ( when the arg isn't set ).

I suspect what's happening before this fix is:

When the `args.tunnel_net` is not set it is instantiating the Tunnel class with a None value for the subnet property here
https://github.com/meshtastic/python/blob/master/meshtastic/__main__.py#L774C18-L774C18
```python
tunnel.Tunnel(interface, subnet=args.tunnel_net)
```

That None value I believe would get set here overriding the default subnet: https://github.com/meshtastic/python/blob/master/meshtastic/tunnel.py#L41
```python
def __init__(self, iface, subnet="10.115", netmask="255.255.0.0"):
```

