### PR TITLE
Issue #366 TCP connection error handling

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -948,9 +948,14 @@ def common():
             if args.ble:
                 client = BLEInterface(args.ble, debugOut=logfile, noProto=args.noproto)
             elif args.host:
-                client = meshtastic.tcp_interface.TCPInterface(
-                    args.host, debugOut=logfile, noProto=args.noproto
-                )
+                try:
+                    client = meshtastic.tcp_interface.TCPInterface(
+                        args.host, debugOut=logfile, noProto=args.noproto
+                    )
+                except Exception as ex:
+                    meshtastic.util.our_exit(
+                        f"Error connecting to {args.host}:{ex}", 1
+                    )
             else:
                 try:
                     client = meshtastic.serial_interface.SerialInterface(


### PR DESCRIPTION
Added except block to args.host to handle connection errors for the CLI.

The stream_interface and mesh_interface raise generic exception types, so that's what I've handled here. If we prefer to raise more specific exception types, let me know and I will work on adding those instead.