### PR TITLE
Extend timeout for slow devices like pi zero

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -591,7 +591,7 @@ class MeshInterface:
             return user.get("shortName", None)
         return None
 
-    def _waitConnected(self, timeout=15.0):
+    def _waitConnected(self, timeout=30.0):
         """Block until the initial node db download is complete, or timeout
         and raise an exception"""
         if not self.noProto:


### PR DESCRIPTION
I have an original pi zero that consistently times out with commands over serial. It happens more now than it used to, so there's somehow a little more overhead than there used to be. It's using python 3.9.2, but I've observed it in a newer version too.