### PR TITLE
Show unknown nodes in a fashion similar to the web UI. Fixes #504

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -152,13 +152,13 @@ class MeshInterface:
             )
 
         rows = []
-        if self.nodes:
+        if self.nodesByNum:
             logging.debug(f"self.nodes:{self.nodes}")
-            for node in self.nodes.values():
+            for node in self.nodesByNum.values():
                 if not includeSelf and node["num"] == self.localNode.nodeNum:
                     continue
 
-                row = {"N": 0}
+                row = {"N": 0, "User": f"UNK: {node['num']}", "ID": f"!{node['num']:x}"}
 
                 user = node.get("user")
                 if user:


### PR DESCRIPTION
Similar to how the web UI shows "UNK: <integer node ID>", this will show that under "User", and the hex ID that can be computed from that under "ID". The change to using `self.nodesByNum` was necessary to pull in those, since `self.nodes` only has nodes that have users, which excludes nodes in this particular state.