### PR TITLE
Set --ch-index to a newly added channel when --ch-add is set, to allow further modification

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -597,6 +597,12 @@ def onConnected(interface):
         # handle changing channels
 
         if args.ch_add:
+            channelIndex = our_globals.get_channel_index()
+            if channelIndex is not None:
+                # Since we set the channel index after adding a channel, don't allow --ch-index
+                meshtastic.util.our_exit(
+                    "Warning: '--ch-add' and '--ch-index' are incompatible. Channel not added."
+                )
             closeNow = True
             if len(args.ch_add) > 10:
                 meshtastic.util.our_exit(
@@ -620,6 +626,9 @@ def onConnected(interface):
                 ch.role = channel_pb2.Channel.Role.SECONDARY
                 print(f"Writing modified channels to device")
                 n.writeChannel(ch.index)
+                if channelIndex is None:
+                    print(f"Setting newly-added channel's {ch.index} as '--ch-index' for further modifications")
+                    our_globals.set_channel_index(ch.index)
 
         if args.ch_del:
             closeNow = True


### PR DESCRIPTION
This isn't quite the fix as described in the issue, but I believe fixes #507 a bit more nicely even than that.

Currently, if you were to pass all of `--ch-add`, `--ch-index`, and `--ch-set`, the CLI would first add a channel at the first available index, but then the `--ch-set` would apply to _whatever_ channel was at `--ch-index`, which needn't necessarily match the channel that was just added. That is, a command like:

```
meshtastic --ch-add test --ch-index 0 --ch-set psk default --ch-set uplink_enabled true
```
would first add "test" as one of channels 1-7 (assuming one was available), and then set the _primary_ channel to the default PSK and turn uplink on.

With this change, `--ch-add` won't allow `--ch-index` to be set along with it, and after adding the channel, will instead set the channel index to that value. That way, the above command would error, but the following:

```
meshtastic --ch-add test --ch-set psk default --ch-set uplink_enabled true
```

would, instead, add a channel called "test" with the default PSK and uplink enabled.

I think this is a lot more intuitive and more in line with the usual philosophy of this command line where a single command is intended, generally, to modify only one thing. Hopefully y'all agree!