### PR TITLE
use importlib.metadata and packaging.version instead of pkg_resources

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -9,7 +9,6 @@ import platform
 import sys
 import time
 
-import pkg_resources
 import pyqrcode
 import yaml
 from google.protobuf.json_format import MessageToDict
@@ -18,6 +17,7 @@ from pubsub import pub
 import meshtastic.test
 import meshtastic.util
 from meshtastic import channel_pb2, config_pb2, portnums_pb2, remote_hardware
+from meshtastic.version import get_active_version
 from meshtastic.__init__ import BROADCAST_ADDR
 from meshtastic.ble_interface import BLEInterface
 from meshtastic.globals import Globals
@@ -1399,7 +1399,7 @@ def initParser():
 
     parser.set_defaults(deprecated=None)
 
-    the_version = pkg_resources.get_distribution("meshtastic").version
+    the_version = get_active_version()
     parser.add_argument("--version", action="version", version=f"{the_version}")
 
     parser.add_argument(

--- a/meshtastic/version.py
+++ b/meshtastic/version.py
@@ -1,0 +1,11 @@
+import sys
+try:
+    from importlib.metadata import version
+except:
+    import pkg_resources
+
+def get_active_version():
+    if "importlib.metadata" in sys.modules:
+        return version("meshtastic")
+    else:
+        return pkg_resources.get_distribution("meshtastic").version

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pytap2
 pdoc3
 pypubsub
 bleak
+packaging

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "timeago>=1.0.15",
         "pyyaml",
         "bleak>=0.21.1",
+        "packaging",
     ],
     extras_require={"tunnel": ["pytap2>=2.0.0"]},
     python_requires=">=3.7",


### PR DESCRIPTION
This will, hopefully, fix or at least improve on the CI situation. I've been having a bit of trouble running a local runner for github actions and getting it to cooperate, but it seems to at least be getting further. We'll see, maybe?