### PR TITLE
feat: Send ping with a channel index

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -395,9 +395,6 @@ def onConnected(interface):
                 )
 
         if args.sendping:
-            channelIndex = 0
-            if args.ch_index is not None:
-                channelIndex = int(args.ch_index)
             payload = str.encode("test string")
             print(f"Sending ping message to {args.dest}")
             interface.sendData(
@@ -406,7 +403,7 @@ def onConnected(interface):
                 portNum=portnums_pb2.PortNum.REPLY_APP,
                 wantAck=True,
                 wantResponse=True,
-                channelIndex=channelIndex,
+                channelIndex=our_globals.get_channel_index() or 0,
             )
 
         if args.traceroute:

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -395,6 +395,9 @@ def onConnected(interface):
                 )
 
         if args.sendping:
+            channelIndex = 0
+            if args.ch_index is not None:
+                channelIndex = int(args.ch_index)
             payload = str.encode("test string")
             print(f"Sending ping message to {args.dest}")
             interface.sendData(
@@ -403,6 +406,7 @@ def onConnected(interface):
                 portNum=portnums_pb2.PortNum.REPLY_APP,
                 wantAck=True,
                 wantResponse=True,
+                channelIndex=channelIndex,
             )
 
         if args.traceroute:

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -722,9 +722,34 @@ def test_main_sendping(capsys):
 
     iface = MagicMock(autospec=SerialInterface)
 
-    def mock_sendData(payload, dest, portNum, wantAck, wantResponse):
+    def mock_sendData(payload, dest, portNum, wantAck, wantResponse, channelIndex):
         print("inside mocked sendData")
-        print(f"{payload} {dest} {portNum} {wantAck} {wantResponse}")
+        print(f"{payload} {dest} {portNum} {wantAck} {wantResponse} {channelIndex}")
+
+    iface.sendData.side_effect = mock_sendData
+
+    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface) as mo:
+        main()
+        out, err = capsys.readouterr()
+        assert re.search(r"Connected to radio", out, re.MULTILINE)
+        assert re.search(r"Sending ping message", out, re.MULTILINE)
+        assert re.search(r"inside mocked sendData", out, re.MULTILINE)
+        assert err == ""
+        mo.assert_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_globals")
+def test_main_sendping_with_channel_index(capsys):
+    """Test --sendping with other ch"""
+    sys.argv = ["", "--sendping", "--ch-index", "1"]
+    Globals.getInstance().set_args(sys.argv)
+
+    iface = MagicMock(autospec=SerialInterface)
+
+    def mock_sendData(payload, dest, portNum, wantAck, wantResponse, channelIndex):
+        print("inside mocked sendData")
+        print(f"{payload} {dest} {portNum} {wantAck} {wantResponse} {channelIndex}")
 
     iface.sendData.side_effect = mock_sendData
 


### PR DESCRIPTION
Now we can send ping messages with a channel index. 
Additionally, a new unit test has been added to simulate this functionality, and other tests have been fixed.

e.g
```sh
$ meshtastic --sendping --ch-index 1 
# output:
# Connected to radio
# Sending ping message to ^all
```