### PR TITLE
When `--listen` is set, turn on debug-level logging

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1367,7 +1367,7 @@ def initParser():
 
     parser.add_argument(
         "--listen",
-        help="Just stay open and listen to the protobuf stream.",
+        help="Just stay open and listen to the protobuf stream. Enables debug logging.",
         action="store_true",
     )
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -919,7 +919,7 @@ def common():
     args = our_globals.get_args()
     parser = our_globals.get_parser()
     logging.basicConfig(
-        level=logging.DEBUG if args.debug else logging.INFO,
+        level=logging.DEBUG if (args.debug or args.listen) else logging.INFO,
         format="%(levelname)s file:%(filename)s %(funcName)s line:%(lineno)s %(message)s",
     )
 


### PR DESCRIPTION
(as though `--debug` was, even if it wasn't explicitly provided)

Fixes #513