### PR TITLE
Show hops away when present in nodeDB (fixes #539)

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -208,6 +208,7 @@ class MeshInterface:
                 row.update(
                     {
                         "SNR": formatFloat(node.get("snr"), 2, " dB"),
+                        "Hops Away": node.get("hopsAway", "unknown"),
                         "Channel": node.get("channel"),
                         "LastHeard": getLH(node.get("lastHeard")),
                         "Since": getTimeAgo(node.get("lastHeard")),


### PR DESCRIPTION
Small update only, probably pending larger updates to `--nodes`. But this is just in nodeDB, no reason not to show it.