### PR TITLE
Allow generating QR codes for remote nodes and for all channels, not just local/primary

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -251,6 +251,9 @@ def onConnected(interface):
             print("Connected to radio")
 
         if args.setlat or args.setlon or args.setalt:
+            if args.dest != BROADCAST_ADDR:
+                print("Setting latitude, longitude, and altitude of remote nodes is not supported.")
+                return
             closeNow = True
 
             alt = 0

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -804,10 +804,14 @@ def onConnected(interface):
                 return
             interface.showNodes()
 
-        if args.qr:
+        if args.qr or args.qr_all:
             closeNow = True
-            url = interface.localNode.getURL(includeAll=False)
-            print(f"Primary channel URL {url}")
+            url = interface.getNode(args.dest, True).getURL(includeAll=args.qr_all)
+            if args.qr_all:
+                urldesc = "Complete URL (includes all channels)"
+            else:
+                urldesc = "Primary channel URL"
+            print(f"{urldesc}: {url}")
             qr = pyqrcode.create(url)
             print(qr.terminal())
 
@@ -1157,7 +1161,16 @@ def initParser():
 
     group.add_argument(
         "--qr",
-        help="Display the QR code that corresponds to the current channel",
+        help=(
+            "Display a QR code for the node's primary channel (or all channels with --qr-all). "
+            "Also shows the shareable channel URL."
+        ),
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--qr-all",
+        help="Display a QR code and URL for all of the node's channels.",
         action="store_true",
     )
 

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -313,6 +313,8 @@ class Node:
                 ):
                     channelSet.settings.append(c.settings)
 
+        if len(self.localConfig.ListFields()) == 0:
+            self.requestConfig(self.localConfig.DESCRIPTOR.fields_by_name.get('lora'))
         channelSet.lora_config.CopyFrom(self.localConfig.lora)
         some_bytes = channelSet.SerializeToString()
         s = base64.urlsafe_b64encode(some_bytes).decode("ascii")

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from .. import mesh_pb2, BROADCAST_ADDR, LOCAL_ADDR
+from .. import mesh_pb2, config_pb2, BROADCAST_ADDR, LOCAL_ADDR
 from ..mesh_interface import MeshInterface
 from ..node import Node
 
@@ -36,11 +36,14 @@ def test_MeshInterface(capsys):
             "lastHeard": 1640204888,
         }
 
+
     iface.nodes = {NODE_ID: node}
     iface.nodesByNum = {NODE_NUM: node}
 
     myInfo = MagicMock()
     iface.myInfo = myInfo
+
+    iface.localNode.localConfig.lora.CopyFrom(config_pb2.Config.LoRaConfig())
 
     iface.showInfo()
     iface.localNode.showInfo()

--- a/meshtastic/tests/test_serial_interface.py
+++ b/meshtastic/tests/test_serial_interface.py
@@ -6,6 +6,7 @@ from unittest.mock import mock_open, patch
 import pytest
 
 from ..serial_interface import SerialInterface
+from .. import config_pb2
 
 
 @pytest.mark.unit
@@ -20,6 +21,7 @@ def test_SerialInterface_single_port(
 ):
     """Test that we can instantiate a SerialInterface with a single port"""
     iface = SerialInterface(noProto=True)
+    iface.localNode.localConfig.lora.CopyFrom(config_pb2.Config.LoRaConfig())
     iface.showInfo()
     iface.localNode.showInfo()
     iface.close()

--- a/meshtastic/tests/test_tcp_interface.py
+++ b/meshtastic/tests/test_tcp_interface.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from .. import config_pb2
 from ..tcp_interface import TCPInterface
 
 
@@ -13,6 +14,7 @@ def test_TCPInterface(capsys):
     """Test that we can instantiate a TCPInterface"""
     with patch("socket.socket") as mock_socket:
         iface = TCPInterface(hostname="localhost", noProto=True)
+        iface.localNode.localConfig.lora.CopyFrom(config_pb2.Config.LoRaConfig())
         iface.myConnect()
         iface.showInfo()
         iface.localNode.showInfo()


### PR DESCRIPTION
plus making tests work again/work more