### PR TITLE
Add missing StoreForward config from radio

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -896,6 +896,10 @@ class MeshInterface:
                 self.localNode.moduleConfig.external_notification.CopyFrom(
                     fromRadio.moduleConfig.external_notification
                 )
+            elif fromRadio.moduleConfig.HasField("store_forward"):
+                self.localNode.moduleConfig.store_forward.CopyFrom(
+                    fromRadio.moduleConfig.store_forward
+                )
             elif fromRadio.moduleConfig.HasField("range_test"):
                 self.localNode.moduleConfig.range_test.CopyFrom(
                     fromRadio.moduleConfig.range_test


### PR DESCRIPTION
`--info` didn't have the StoreForward config and `--get store_forward.enabled` would always return `false` due to missing config handler.