### PR TITLE
Pretty indent --info JSON output (see below for details)

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -133,7 +133,7 @@ class MeshInterface:
                 # use id as dictionary key for correct json format in list of nodes
                 nodeid = n2["user"]["id"]
                 nodes[nodeid] = n2
-        infos = owner + myinfo + metadata + mesh + json.dumps(nodes)
+        infos = owner + myinfo + metadata + mesh + json.dumps(nodes, indent=2)
         print(infos)
         return infos
 

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -64,11 +64,11 @@ class Node:
         """Show human readable description of our node"""
         prefs = ""
         if self.localConfig:
-            prefs = message_to_json(self.localConfig)
+            prefs = message_to_json(self.localConfig, multiline=True)
         print(f"Preferences: {prefs}\n")
         prefs = ""
         if self.moduleConfig:
-            prefs = message_to_json(self.moduleConfig)
+            prefs = message_to_json(self.moduleConfig, multiline=True)
         print(f"Module preferences: {prefs}\n")
         self.showChannels()
 

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -627,6 +627,8 @@ def check_if_newer_version():
 
     return pypi_version
 
-def message_to_json(message):
-    "Return protobuf message as JSON. Always print all fields, even when not present in data."
-    return stripnl(MessageToJson(message, always_print_fields_with_no_presence=True))
+
+def message_to_json(message, multiline=False):
+    """Return protobuf message as JSON. Always print all fields, even when not present in data."""
+    json = MessageToJson(message, always_print_fields_with_no_presence=True)
+    return stripnl(json) if not multiline else json


### PR DESCRIPTION
Changes to make --info much more human readable (while still keeping machine readabilty for anyone foolish enough to be parsing the existing output as text)

* change message_to_json to optionally not strip the multiline JSON
* use multiline=True for the two places we are printing to the console
* make the node list JSON indented

## Old output looked like:
```
Owner: geeksville2 (gk2)
My info: { "myNodeNum": 2885173400, "rebootCount": 112, "minAppVersion": 30200 }
Metadata: { "firmwareVersion": "2.3.7.57d296e0", "deviceStateVersion": 22, "canShutdown": true, "hasWifi": true, "hasBluetooth": true, "positionFlags": 811, "hwModel": "TBEAM", "hasEthernet": false, "role": "CLIENT", "hasRemoteHardware": false }

Nodes in mesh: {"!abf84098": {"num": 2885173400, "user": {"id": "!abf84098", "longName": "geeksville2", "shortName": "gk2", "macaddr": "24:62:ab:f8:40:98", "hwModel": "TBEAM"}, "position": {"latitudeI": 375209556, "longitudeI": -1223090555, "altitude": 156, "time": 1714168740, "locationSource": "LOC_INTERNAL", "latitude": 37.5209556, "longitude": -122.3090555}, "lastHeard": 1714168740, "deviceMetrics": {"batteryLevel": 101, "voltage": 3.877, "channelUtilization": 1.6433334, "airUtilTx": 0.19416668, "uptimeSeconds": 526}, "isFavorite": true}, "!da5476dc": {"num": 3662968540, "user": {"id": "!da5476dc", "longName": "Meshtastic Ducky 3", "shortName": "duc3", "macaddr": "34:b7:da:54:76:dc", "hwModel": "HELTEC_V3", "role": "CLIENT_HIDDEN"}}, "!abdddf38": {"num": 2883444536, "user": {"id": "!abdddf38", "longName": "geeksville", "shortName": "gk", "macaddr": "24:62:ab:dd:df:38", "hwModel": "TBEAM"}, "position": {"latitudeI": 375210000, "longitudeI": -1223070000, "time": 1714168138, "latitude": 37.521, "longitude": -122.30699999999999}, "snr": 10.0, "lastHeard": 1714168145, "deviceMetrics": {"batteryLevel": 101, "voltage": 4.158, "channelUtilization": 2.5900002, "airUtilTx": 1.2397778, "uptimeSeconds": 4547}}, "!f96a9154": {"num": 4184510804, "user": {"id": "!f96a9154", "longName": "Meshtastic 9154", "shortName": "9154", "macaddr": "08:d1:f9:6a:91:54", "hwModel": "TBEAM", "role": "ROUTER_CLIENT"}, "snr": 11.25, "lastHeard": 1714168612, "deviceMetrics": {"batteryLevel": 100, "voltage": 4.154, "channelUtilization": 4.366667, "airUtilTx": 1.1706111}, "lastReceived": {"from": 4184510804, "to": 1273181129, "id": 2059670816, "rxTime": 1714168612, "rxSnr": 11.25, "hopLimit": 6, "rxRssi": -79, "fromId": "!f96a9154", "toId": null}, "hopLimit": 6}, "!cb2c6c4b": {"num": 3408686155, "user": {"id": "!cb2c6c4b", "longName": "Meshtastic 6c4b", "shortName": "6c4b", "macaddr": "e7:95:cb:2c:6c:4b", "hwModel": "RAK4631", "role": "ROUTER"}, "position": {"latitudeI": 377677491, "longitudeI": -1224190070, "altitude": 17, "time": 1714168389, "latitude": 37.767749099999996, "longitude": -122.419007}, "snr": 11.5, "lastHeard": 1714168178}, "!f76b3596": {"num": 2504137764, "user": {"id": "!f76b3596", "longName": "P", "shortName": "3596", "macaddr": "ca:20:f7:6b:35:96", "hwModel": "CANARYONE", "role": "ROUTER_CLIENT"}, "snr": 11.0, "lastHeard": 1714168203, "hopsAway": 2}, "!1c37bfbc": {"num": 473415612, "user": {"id": "!1c37bfbc", "longName": "G1 Base", "shortName": "G1B", "macaddr": "b0:b2:1c:37:bf:bc", "hwModel": "STATION_G1"}, "snr": 10.0, "lastHeard": 1714168597, "lastReceived": {"from": 473415612, "to": 4294967295, "id": 64514357, "rxTime": 1714168597, "rxSnr": 10.0, "hopLimit": 1, "rxRssi": -77, "fromId": "!1c37bfbc", "toId": "^all"}, "hopLimit": 1}}

Preferences: { "device": { "serialEnabled": true, "nodeInfoBroadcastSecs": 10800, "role": "CLIENT", "debugLogEnabled": false, "buttonGpio": 0, "buzzerGpio": 0, "rebroadcastMode": "ALL", "doubleTapAsButtonPress": false, "isManaged": false, "disableTripleClick": false, "tzdef": "", "ledHeartbeatDisabled": false }, "position": { "positionBroadcastSecs": 900, "positionBroadcastSmartEnabled": true, "gpsUpdateInterval": 120, "positionFlags": 811, "broadcastSmartMinimumDistance": 100, "broadcastSmartMinimumIntervalSecs": 30, "gpsMode": "ENABLED", "fixedPosition": false, "gpsEnabled": false, "gpsAttemptTime": 0, "rxGpio": 0, "txGpio": 0, "gpsEnGpio": 0 }, "power": { "waitBluetoothSecs": 60, "sdsSecs": 4294967295, "lsSecs": 300, "minWakeSecs": 10, "isPowerSaving": false, "onBatteryShutdownAfterSecs": 0, "adcMultiplierOverride": 0.0, "deviceBatteryInaAddress": 0 }, "network": { "wifiSsid": "geeksville", "wifiPsk": "XXX", "ntpServer": "0.pool.ntp.org", "ethEnabled": true, "wifiEnabled": false, "addressMode": "DHCP", "rsyslogServer": "" }, "display": { "screenOnSecs": 600, "gpsFormat": "DEC", "autoScreenCarouselSecs": 0, "compassNorthTop": false, "flipScreen": false, "units": "METRIC", "oled": "OLED_AUTO", "displaymode": "DEFAULT", "headingBold": false, "wakeOnTapOrMotion": false }, "lora": { "usePreset": true, "region": "US", "hopLimit": 3, "txEnabled": true, "txPower": 30, "sx126xRxBoostedGain": true, "modemPreset": "LONG_FAST", "bandwidth": 0, "spreadFactor": 0, "codingRate": 0, "frequencyOffset": 0.0, "channelNum": 0, "overrideDutyCycle": false, "overrideFrequency": 0.0, "ignoreIncoming": [], "ignoreMqtt": false }, "bluetooth": { "enabled": true, "fixedPin": 123456, "mode": "RANDOM_PIN" }, "version": 0 }

Module preferences: { "mqtt": { "enabled": true, "address": "mqtt.meshtastic.org", "username": "meshdev", "password": "large4cats", "encryptionEnabled": true, "root": "msh/US", "jsonEnabled": false, "tlsEnabled": false, "proxyToClientEnabled": false, "mapReportingEnabled": false }, "serial": { "enabled": false, "echo": false, "rxd": 0, "txd": 0, "baud": "BAUD_DEFAULT", "timeout": 0, "mode": "DEFAULT", "overrideConsoleSerialPort": false }, "externalNotification": { "enabled": false, "outputMs": 0, "output": 0, "outputVibra": 0, "outputBuzzer": 0, "active": false, "alertMessage": false, "alertMessageVibra": false, "alertMessageBuzzer": false, "alertBell": false, "alertBellVibra": false, "alertBellBuzzer": false, "usePwm": false, "nagTimeout": 0, "useI2sAsBuzzer": false }, "storeForward": { "enabled": false, "heartbeat": false, "records": 0, "historyReturnMax": 0, "historyReturnWindow": 0 }, "rangeTest": { "enabled": false, "sender": 0, "save": false }, "telemetry": { "deviceUpdateInterval": 900, "environmentUpdateInterval": 900, "airQualityInterval": 900, "environmentMeasurementEnabled": false, "environmentScreenEnabled": false, "environmentDisplayFahrenheit": false, "airQualityEnabled": false, "powerMeasurementEnabled": false, "powerUpdateInterval": 0, "powerScreenEnabled": false }, "cannedMessage": { "rotary1Enabled": false, "inputbrokerPinA": 0, "inputbrokerPinB": 0, "inputbrokerPinPress": 0, "inputbrokerEventCw": "NONE", "inputbrokerEventCcw": "NONE", "inputbrokerEventPress": "NONE", "updown1Enabled": false, "enabled": false, "allowInputSource": "", "sendBell": false }, "audio": { "codec2Enabled": false, "pttPin": 0, "bitrate": "CODEC2_DEFAULT", "i2sWs": 0, "i2sSd": 0, "i2sDin": 0, "i2sSck": 0 }, "remoteHardware": { "enabled": false, "allowUndefinedPinAccess": false, "availablePins": [] }, "neighborInfo": { "updateInterval": 900, "enabled": false }, "ambientLighting": { "current": 10, "red": 248, "green": 64, "blue": 152, "ledState": false }, "detectionSensor": { "minimumBroadcastSecs": 45, "detectionTriggeredHigh": true, "enabled": false, "stateBroadcastSecs": 0, "sendBell": false, "name": "", "monitorPin": 0, "usePullup": false }, "paxcounter": { "enabled": false, "paxcounterUpdateInterval": 0 }, "version": 0 }

Channels:
  Index 0: PRIMARY psk=default { "psk": "AQ==", "moduleSettings": { "positionPrecision": 32 }, "channelNum": 0, "name": "", "id": 0, "uplinkEnabled": false, "downlinkEnabled": false }

Primary channel URL: https://meshtastic.org/e/#CgcSAQE6AgggEgwIATgBQANIAVAeaAE
```

## New output looks like
```
Owner: geeksville2 (gk2)
My info: { "myNodeNum": 2885173400, "rebootCount": 112, "minAppVersion": 30200 }
Metadata: { "firmwareVersion": "2.3.7.57d296e0", "deviceStateVersion": 22, "canShutdown": true, "hasWifi": true, "hasBluetooth": true, "positionFlags": 811, "hwModel": "TBEAM", "hasEthernet": false, "role": "CLIENT", "hasRemoteHardware": false }

Nodes in mesh: {
  "!abf84098": {
    "num": 2885173400,
    "user": {
      "id": "!abf84098",
      "longName": "geeksville2",
      "shortName": "gk2",
      "macaddr": "24:62:ab:f8:40:98",
      "hwModel": "TBEAM"
    },
    "position": {
      "latitudeI": 375211061,
      "longitudeI": -1223090833,
      "altitude": 158,
      "time": 1714169201,
      "locationSource": "LOC_INTERNAL",
      "latitude": 37.5211061,
      "longitude": -122.3090833
    },
    "lastHeard": 1714169201,
    "deviceMetrics": {
      "batteryLevel": 101,
      "voltage": 3.913,
      "channelUtilization": 2.5900002,
      "airUtilTx": 0.47577778,
      "uptimeSeconds": 1306
    },
    "isFavorite": true
  },
  "!da5476dc": {
    "num": 3662968540,
    "user": {
      "id": "!da5476dc",
      "longName": "Meshtastic Ducky 3",
      "shortName": "duc3",
      "macaddr": "34:b7:da:54:76:dc",
      "hwModel": "HELTEC_V3",
      "role": "CLIENT_HIDDEN"
    }
  },
  "!abdddf38": {
    "num": 2883444536,
    "user": {
      "id": "!abdddf38",
      "longName": "geeksville",
      "shortName": "gk",
      "macaddr": "24:62:ab:dd:df:38",
      "hwModel": "TBEAM"
    },
    "position": {
      "latitudeI": 375210000,
      "longitudeI": -1223070000,
      "time": 1714168959,
      "latitude": 37.521,
      "longitude": -122.30699999999999
    },
    "snr": 10.5,
    "lastHeard": 1714168991,
    "deviceMetrics": {
      "batteryLevel": 101,
      "voltage": 4.186,
      "channelUtilization": 12.610001,
      "airUtilTx": 1.4225278,
      "uptimeSeconds": 5447
    }
  },
  "!f96a9154": {
    "num": 4184510804,
    "user": {
      "id": "!f96a9154",
      "longName": "Meshtastic 9154",
      "shortName": "9154",
      "macaddr": "08:d1:f9:6a:91:54",
      "hwModel": "TBEAM",
      "role": "ROUTER_CLIENT"
    },
    "snr": -18.25,
    "lastHeard": 1714169032,
    "deviceMetrics": {
      "batteryLevel": 100,
      "voltage": 4.151,
      "airUtilTx": 1.2857223
    }
  },
  "!cb2c6c4b": {
    "num": 3408686155,
    "user": {
      "id": "!cb2c6c4b",
      "longName": "Meshtastic 6c4b",
      "shortName": "6c4b",
      "macaddr": "e7:95:cb:2c:6c:4b",
      "hwModel": "RAK4631",
      "role": "ROUTER"
    },
    "position": {
      "latitudeI": 377677491,
      "longitudeI": -1224190070,
      "altitude": 17,
      "time": 1714168389,
      "latitude": 37.767749099999996,
      "longitude": -122.419007
    },
    "snr": 13.25,
    "lastHeard": 1714169073,
    "deviceMetrics": {
      "batteryLevel": 101,
      "voltage": 4.318,
      "channelUtilization": 7.1783333,
      "airUtilTx": 1.4095278
    }
  },
  "!f76b3596": {
    "num": 2504137764,
    "user": {
      "id": "!f76b3596",
      "longName": "P",
      "shortName": "3596",
      "macaddr": "ca:20:f7:6b:35:96",
      "hwModel": "CANARYONE",
      "role": "ROUTER_CLIENT"
    },
    "snr": 11.0,
    "lastHeard": 1714168203,
    "hopsAway": 2
  },
  "!1c37bfbc": {
    "num": 473415612,
    "user": {
      "id": "!1c37bfbc",
      "longName": "G1 Base",
      "shortName": "G1B",
      "macaddr": "b0:b2:1c:37:bf:bc",
      "hwModel": "STATION_G1"
    },
    "snr": 10.0,
    "lastHeard": 1714168597
  },
  "!e2e2db5c": {
    "num": 3806518108,
    "user": {
      "id": "!e2e2db5c",
      "longName": "ENTS 24",
      "shortName": "E24",
      "macaddr": "48:27:e2:e2:db:5c",
      "hwModel": "HELTEC_V3"
    },
    "lastReceived": {
      "from": 3806518108,
      "to": 1273181129,
      "id": 1939877053,
      "rxTime": 1714169179,
      "rxSnr": -17.25,
      "hopLimit": 4,
      "rxRssi": -137,
      "fromId": "!e2e2db5c",
      "toId": null
    },
    "lastHeard": 1714169179,
    "snr": -17.25,
    "hopLimit": 4
  }
}

Preferences: {
  "device": {
    "serialEnabled": true,
    "nodeInfoBroadcastSecs": 10800,
    "role": "CLIENT",
    "debugLogEnabled": false,
    "buttonGpio": 0,
    "buzzerGpio": 0,
    "rebroadcastMode": "ALL",
    "doubleTapAsButtonPress": false,
    "isManaged": false,
    "disableTripleClick": false,
    "tzdef": "",
    "ledHeartbeatDisabled": false
  },
  "position": {
    "positionBroadcastSecs": 900,
    "positionBroadcastSmartEnabled": true,
    "gpsUpdateInterval": 120,
    "positionFlags": 811,
    "broadcastSmartMinimumDistance": 100,
    "broadcastSmartMinimumIntervalSecs": 30,
    "gpsMode": "ENABLED",
    "fixedPosition": false,
    "gpsEnabled": false,
    "gpsAttemptTime": 0,
    "rxGpio": 0,
    "txGpio": 0,
    "gpsEnGpio": 0
  },
  "power": {
    "waitBluetoothSecs": 60,
    "sdsSecs": 4294967295,
    "lsSecs": 300,
    "minWakeSecs": 10,
    "isPowerSaving": false,
    "onBatteryShutdownAfterSecs": 0,
    "adcMultiplierOverride": 0.0,
    "deviceBatteryInaAddress": 0
  },
  "network": {
    "wifiSsid": "geeksville",
    "wifiPsk": "XXX",
    "ntpServer": "0.pool.ntp.org",
    "ethEnabled": true,
    "wifiEnabled": false,
    "addressMode": "DHCP",
    "rsyslogServer": ""
  },
  "display": {
    "screenOnSecs": 600,
    "gpsFormat": "DEC",
    "autoScreenCarouselSecs": 0,
    "compassNorthTop": false,
    "flipScreen": false,
    "units": "METRIC",
    "oled": "OLED_AUTO",
    "displaymode": "DEFAULT",
    "headingBold": false,
    "wakeOnTapOrMotion": false
  },
  "lora": {
    "usePreset": true,
    "region": "US",
    "hopLimit": 3,
    "txEnabled": true,
    "txPower": 30,
    "sx126xRxBoostedGain": true,
    "modemPreset": "LONG_FAST",
    "bandwidth": 0,
    "spreadFactor": 0,
    "codingRate": 0,
    "frequencyOffset": 0.0,
    "channelNum": 0,
    "overrideDutyCycle": false,
    "overrideFrequency": 0.0,
    "ignoreIncoming": [],
    "ignoreMqtt": false
  },
  "bluetooth": {
    "enabled": true,
    "fixedPin": 123456,
    "mode": "RANDOM_PIN"
  },
  "version": 0
}

Module preferences: {
  "mqtt": {
    "enabled": true,
    "address": "mqtt.meshtastic.org",
    "username": "meshdev",
    "password": "large4cats",
    "encryptionEnabled": true,
    "root": "msh/US",
    "jsonEnabled": false,
    "tlsEnabled": false,
    "proxyToClientEnabled": false,
    "mapReportingEnabled": false
  },
  "serial": {
    "enabled": false,
    "echo": false,
    "rxd": 0,
    "txd": 0,
    "baud": "BAUD_DEFAULT",
    "timeout": 0,
    "mode": "DEFAULT",
    "overrideConsoleSerialPort": false
  },
  "externalNotification": {
    "enabled": false,
    "outputMs": 0,
    "output": 0,
    "outputVibra": 0,
    "outputBuzzer": 0,
    "active": false,
    "alertMessage": false,
    "alertMessageVibra": false,
    "alertMessageBuzzer": false,
    "alertBell": false,
    "alertBellVibra": false,
    "alertBellBuzzer": false,
    "usePwm": false,
    "nagTimeout": 0,
    "useI2sAsBuzzer": false
  },
  "storeForward": {
    "enabled": false,
    "heartbeat": false,
    "records": 0,
    "historyReturnMax": 0,
    "historyReturnWindow": 0
  },
  "rangeTest": {
    "enabled": false,
    "sender": 0,
    "save": false
  },
  "telemetry": {
    "deviceUpdateInterval": 900,
    "environmentUpdateInterval": 900,
    "airQualityInterval": 900,
    "environmentMeasurementEnabled": false,
    "environmentScreenEnabled": false,
    "environmentDisplayFahrenheit": false,
    "airQualityEnabled": false,
    "powerMeasurementEnabled": false,
    "powerUpdateInterval": 0,
    "powerScreenEnabled": false
  },
  "cannedMessage": {
    "rotary1Enabled": false,
    "inputbrokerPinA": 0,
    "inputbrokerPinB": 0,
    "inputbrokerPinPress": 0,
    "inputbrokerEventCw": "NONE",
    "inputbrokerEventCcw": "NONE",
    "inputbrokerEventPress": "NONE",
    "updown1Enabled": false,
    "enabled": false,
    "allowInputSource": "",
    "sendBell": false
  },
  "audio": {
    "codec2Enabled": false,
    "pttPin": 0,
    "bitrate": "CODEC2_DEFAULT",
    "i2sWs": 0,
    "i2sSd": 0,
    "i2sDin": 0,
    "i2sSck": 0
  },
  "remoteHardware": {
    "enabled": false,
    "allowUndefinedPinAccess": false,
    "availablePins": []
  },
  "neighborInfo": {
    "updateInterval": 900,
    "enabled": false
  },
  "ambientLighting": {
    "current": 10,
    "red": 248,
    "green": 64,
    "blue": 152,
    "ledState": false
  },
  "detectionSensor": {
    "minimumBroadcastSecs": 45,
    "detectionTriggeredHigh": true,
    "enabled": false,
    "stateBroadcastSecs": 0,
    "sendBell": false,
    "name": "",
    "monitorPin": 0,
    "usePullup": false
  },
  "paxcounter": {
    "enabled": false,
    "paxcounterUpdateInterval": 0
  },
  "version": 0
}
```