### PR TITLE
(high-pri fix) Update python client to use the 'modern' meshtastic protocol init flow

### DIFF
--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -72,6 +72,11 @@ class Node:
         print(f"Module preferences: {prefs}\n")
         self.showChannels()
 
+    def setChannels(self, channels):
+        """Set the channels for this node"""
+        self.channels = channels
+        self._fixupChannels()
+
     def requestChannels(self):
         """Send regular MeshPackets to ask channels."""
         logging.debug(f"requestChannels for nodeNum:{self.nodeNum}")
@@ -654,7 +659,7 @@ class Node:
         """Fixup indexes and add disabled channels as needed"""
 
         # Add extra disabled channels as needed
-        # TODO: These 2 lines seem to not do anything.
+        # This is needed because the protobufs will have index **missing** if the channel number is zero
         for index, ch in enumerate(self.channels):
             ch.index = index  # fixup indexes
 
@@ -726,9 +731,6 @@ class Node:
 
             self.channels = self.partialChannels
             self._fixupChannels()
-
-            # FIXME, the following should only be called after we have settings and channels
-            self.iface._connected()  # Tell everyone else we are ready to go
         else:
             self._requestChannel(index + 1)
 


### PR DESCRIPTION
Some time ago I updated the protocol so that after sending NODEINFOs to client devices (via fromRadio protobufs), it would proactively send the channel definitions.  Prior to this the client had to ask for each channel by sending an admin request.  This handshaking was really slow for mobile/ bluetooth clients.  So in the current device code (last couple of years) the device automatically sends this info to the client during initial config download.

Unfortunately I never updated the python client to expect this.  I assumed (incorrectly) that it would just cope and keep sending the channel requests the old way it always had (which is still supported by devices - and required for remote administration of nodes).

This change removes sending channel requests (for the local node only) from the python startup code.  It also now understands (no longer ignoring) the channels which were sent proactively by the local device.

This makes connection/config/api operations from the python client 100% reliable again.  Previously it would only work sometimes depending on how quickly it was able to get the local node db downloaded.  This was especially obvious if using the wifi interface to talk to the meshtastic node.

Also this flow is much faster - which should help all users of the python api (even when connecting locally via serial/USB).

## Old behavior
about 50% of connection attempts would fail.
```
 meshtastic --host 192.168.86.169
 ... Error connecting to 192.168.86.169:Timed out waiting for connection completion
 ```
 
 ## New behavior
 100% of attempts succeed