### PR TITLE
Use the new Heartbeat payload variant for the heartbeat instead of an empty ToRadio packet

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -683,6 +683,7 @@ class MeshInterface:
                 self.heartbeatTimer = threading.Timer(i, callback)
                 self.heartbeatTimer.start()
                 p = mesh_pb2.ToRadio()
+                p.heartbeat.CopyFrom(mesh_pb2.Heartbeat())
                 self._sendToRadio(p)
 
         callback()  # run our periodic callback now, it will make another timer if necessary


### PR DESCRIPTION
Basically doing (part of) what meshtastic/rust#11 did. Protobufs change was done in meshtastic/protobufs#462 and meshtastic/protobufs#465