### PR TITLE
Print 0 for channel rather than N/A, since we should probably always have a channel

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -211,8 +211,8 @@ class MeshInterface:
                 row.update(
                     {
                         "SNR": formatFloat(node.get("snr"), 2, " dB"),
-                        "Hops Away": node.get("hopsAway", "unknown"),
-                        "Channel": node.get("channel"),
+                        "Hops Away": node.get("hopsAway", "0/unknown"),
+                        "Channel": node.get("channel", 0),
                         "LastHeard": getLH(node.get("lastHeard")),
                         "Since": getTimeAgo(node.get("lastHeard")),
                     }


### PR DESCRIPTION
Fixes #562

Also does similarly for "Hops Away", but that one shows "0/unknown", since older firmwares will still fall under "unknown".