### PR TITLE
add a warning on --ch-enable and --ch-disable, which should usually be avoided

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -721,6 +721,10 @@ def onConnected(interface):
             ch = interface.getNode(args.dest).channels[channelIndex]
 
             if args.ch_enable or args.ch_disable:
+                print(
+                    "Warning: --ch-enable and --ch-disable can produce noncontiguous channels, "
+                    "which can cause errors in some clients. Whenever possible, use --ch-add and --ch-del instead."
+                )
                 if channelIndex == 0:
                     meshtastic.util.our_exit(
                         "Warning: Cannot enable/disable PRIMARY channel."


### PR DESCRIPTION
These options allow for noncontiguous channel configurations (e.g. a primary channel 0, a disabled channel 1, but an enabled secondary channel 20, which clients and things are generally not written to accommodate. It's not per se _wrong_ but can break things, so this adds a warning directing users to `--ch-add` and `--ch-del`, which won't produce these outcomes.