### PR TITLE
Initialize unknown nodes more in line with meshtastic/design#16; show hardware in --nodes

### DIFF
--- a/meshtastic/tests/test_init.py
+++ b/meshtastic/tests/test_init.py
@@ -44,7 +44,7 @@ def test_init_onNodeInfoReceive(caplog, iface_with_nodes):
     iface = iface_with_nodes
     iface.myInfo.my_node_num = 2475227164
     packet = {
-        "from": "foo",
+        "from": 4808675309,
         "decoded": {
             "user": {
                 "id": "bar",

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -588,7 +588,7 @@ def test_getOrCreateByNum_minimal(iface_with_nodes):
     iface = iface_with_nodes
     iface.myInfo.my_node_num = 2475227164
     tmp = iface._getOrCreateByNum(123)
-    assert tmp == {"num": 123}
+    assert tmp == {"num": 123, "user": {"hwModel": "UNSET", "id": "!0000007b", "shortName": "007b", "longName": "Meshtastic 007b"}}
 
 
 @pytest.mark.unit


### PR DESCRIPTION
After some discussion this seems like a pretty good standard way of displaying these nodes. I added a hardware column to the `--nodes` output as well, since this affects the values in that field.