### PR TITLE
Fix rounding of position values when converting from integer to float in _fixupPosition

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -9,6 +9,7 @@ import sys
 import threading
 import time
 from datetime import datetime
+from decimal import Decimal
 
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -978,9 +979,9 @@ class MeshInterface:
         Returns the position with the updated keys
         """
         if "latitudeI" in position:
-            position["latitude"] = position["latitudeI"] * 1e-7
+            position["latitude"] = float(position["latitudeI"] * Decimal("1e-7"))
         if "longitudeI" in position:
-            position["longitude"] = position["longitudeI"] * 1e-7
+            position["longitude"] = float(position["longitudeI"] * Decimal("1e-7"))
         return position
 
     def _nodeNumToId(self, num):


### PR DESCRIPTION
Fixes #572

Luckily, `decimal` is standard library, so this is pretty easy to fix.

The issue here is this:

```
>>> Decimal(1e-7)
Decimal('9.99999999999999954748111825886258685613938723690807819366455078125E-8')
>>> Decimal("1e-7")
Decimal('1E-7')
```

So some positions were ending up as the wrong value due to the multiplication with not _quite_ an actual power of 10.