### PR TITLE
Replace timeago

### DIFF
--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -76,7 +76,7 @@ from typing import *
 
 import google.protobuf.json_format
 import serial # type: ignore[import-untyped]
-import timeago # type: ignore[import-untyped]
+from dotmap import DotMap # type: ignore[import-untyped]
 from google.protobuf.json_format import MessageToJson
 from pubsub import pub # type: ignore[import-untyped]
 from tabulate import tabulate

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -41,6 +41,29 @@ from meshtastic.util import (
 )
 
 
+def _timeago(delta_secs: int) -> str:
+    """Convert a number of seconds in the past into a short, friendly string
+    e.g. "now", "30 sec ago",  "1 hour ago"
+    Zero or negative intervals simply return "now"
+    """
+    intervals = (
+        ("year", 60 * 60 * 24 * 365),
+        ("month", 60 * 60 * 24 * 30),
+        ("day", 60 * 60 * 24),
+        ("hour", 60 * 60),
+        ("min", 60),
+        ("sec", 1),
+    )
+    for name, interval_duration in intervals:
+        if delta_secs < interval_duration:
+            continue
+        x = delta_secs // interval_duration
+        plur = "s" if x > 1 else ""
+        return f"{x} {name}{plur} ago"
+
+    return "now"
+
+
 class MeshInterface: # pylint: disable=R0902
     """Interface class for meshtastic devices
 
@@ -163,22 +186,7 @@ class MeshInterface: # pylint: disable=R0902
             delta_secs = int(delta.total_seconds())
             if delta_secs < 0:
                 return None  # not handling a timestamp from the future
-            intervals = (
-                ("year", 60 * 60 * 24 * 365),
-                ("month", 60 * 60 * 24 * 30),
-                ("day", 60 * 60 * 24),
-                ("hour", 60 * 60),
-                ("min", 60),
-                ("sec", 1),
-            )
-            for name, interval_duration in intervals:
-                if delta_secs < interval_duration:
-                    continue
-                x = delta_secs // interval_duration
-                plur = "s" if x > 1 else ""
-                return f"{x} {name}{plur} ago"
-
-            return "now"
+            return _timeago(delta_secs)
 
         rows: List[Dict[str, Any]] = []
         if self.nodesByNum:

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from .. import mesh_pb2, config_pb2, BROADCAST_ADDR, LOCAL_ADDR
-from ..mesh_interface import MeshInterface
+from ..mesh_interface import MeshInterface, _timeago
 from ..node import Node
 
 # TODO
@@ -684,3 +684,14 @@ def test_waitConnected_isConnected_timeout(capsys):
         out, err = capsys.readouterr()
         assert re.search(r"warn about something", err, re.MULTILINE)
         assert out == ""
+
+
+@pytest.mark.unit
+def test_timeago():
+    assert _timeago(0) == "now"
+    assert _timeago(1) == "1 sec ago"
+    assert _timeago(15) == "15 secs ago"
+    assert _timeago(333) == "5 mins ago"
+    assert _timeago(99999) == "1 day ago"
+    assert _timeago(9999999) == "3 months ago"
+    assert _timeago(-999) == "now"

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         "dotmap>=1.3.14",
         "pyqrcode>=1.2.1",
         "tabulate>=0.8.9",
-        "timeago>=1.0.15",
         "pyyaml",
         "bleak>=0.21.1",
         "packaging",


### PR DESCRIPTION
Replace the timeago library with a simple function. This reduces the amount of Python dependencies making the tool easier to package for Linux distributions. Additionally it handles unexpected timestamps from the future, if any, by returning `None`