### PR TITLE
Improve ACK handling: pass to `onAckNak` and on request in sendData

### DIFF
--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -127,6 +127,7 @@ class ResponseHandler(NamedTuple):
 
     # requestId: int - used only as a key
     callback: Callable
+    ackPermitted: bool = False
     # FIXME, add timestamp and age out old requests
 
 


### PR DESCRIPTION
correctly pass them to `onAckNak` handlers, and add a mechanism for other handlers to request acks as well.

issue discovered looking at #594; not marking that fully closed though, because there's still an improvement to be made there in having implicit ACKs be ignored if a full ack desired/expected