### PR TITLE
make specifying an argument to --seriallog optional

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -164,7 +164,7 @@
       "request": "launch",
       "module": "meshtastic",
       "justMyCode": true,
-      "args": ["--debug", "--seriallog", "stdout"]
+      "args": ["--debug", "--seriallog"]
     },
     {
       "name": "meshtastic test",

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1170,7 +1170,10 @@ def initParser():
 
     group.add_argument(
         "--seriallog",
-        help="Log device serial output to either 'stdout', 'none' or a filename to append to.",
+        help="Log device serial output to either 'none' or a filename to append to.  Defaults to 'stdout' if no filename specified.",
+        nargs='?',
+        const="stdout",
+        default=None
     )
 
     group.add_argument(


### PR DESCRIPTION
thanks @ianmcorvidae for telling me about the cool nargs='?' option!