### PR TITLE
Add bin/git-resolve-poetry-lock.sh to resolve merge conficts

### DIFF
--- a/bin/git-resolve-poetry-lock.sh
+++ b/bin/git-resolve-poetry-lock.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+# This is a little helper you can use to resolve git merge conflicts in poetry.lock
+# with minimal changes vs the requested lib versions
+# Based on this article with a good description of best practices:
+# https://www.peterbe.com/plog/how-to-resolve-a-git-conflict-in-poetry.lock
+
+echo "Resolving poetry.lock merge conflicts, you'll need to run git commit yourself..."
+
+# Get poetry.lock to look like it does in master
+git checkout --theirs poetry.lock
+# Rewrite the lock file
+poetry lock --no-update
+git add poetry.lock
+
+# Update your poetry env to match the new merged lock file
+poetry install


### PR DESCRIPTION
Previously I was just doing poetry update to resolve such conflicts, but that's not really ideal because it updates all libs. poetry lock --no-update is better, but even better to base the changes from their version of poetry-lock and then add only my changes as required by pyproject.yaml.

You can use this script if you get a merge conflict with poetry.lock and it will just do the right thing.

btw: in my powermon/structuredlogging branch I have a commit to add support for the "poe" tool which will provide a shortcut for this script.