### PR TITLE
Fix for hopLimit param on sendTraceRoute not being respected

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -566,7 +566,13 @@ class MeshInterface: # pylint: disable=R0902
     def _addResponseHandler(self, requestId: int, callback: Callable[[dict], Any], ackPermitted: bool=False):
         self.responseHandlers[requestId] = ResponseHandler(callback=callback, ackPermitted=ackPermitted)
 
-    def _sendPacket(self, meshPacket: mesh_pb2.MeshPacket, destinationId: Union[int,str]=BROADCAST_ADDR, wantAck: bool=False, hopLimit: Optional[int]=None):
+    def _sendPacket(
+        self,
+        meshPacket: mesh_pb2.MeshPacket,
+        destinationId: Union[int,str]=BROADCAST_ADDR,
+        wantAck: bool=False,
+        hopLimit: Optional[int]=None
+    ):
         """Send a MeshPacket to the specified node (or if unspecified, broadcast).
         You probably don't want this - use sendData instead.
 

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -325,6 +325,7 @@ class MeshInterface: # pylint: disable=R0902
         onResponse: Optional[Callable[[dict], Any]]=None,
         onResponseAckPermitted: bool=False,
         channelIndex: int=0,
+        hopLimit: Optional[int]=None,
     ):
         """Send a data packet to some other node
 
@@ -347,7 +348,8 @@ class MeshInterface: # pylint: disable=R0902
                     for regular ACKs (True) or just data responses & NAKs (False)
                     Note that if the onResponse callback is called 'onAckNak' this
                     will implicitly be true.
-            channelIndex - channel number to use
+            channelIndex -- channel number to use
+            hopLimit -- hop limit to use
 
         Returns the sent packet. The id field will be populated in this packet
         and can be used to track future message acks/naks.
@@ -379,7 +381,7 @@ class MeshInterface: # pylint: disable=R0902
         if onResponse is not None:
             logging.debug(f"Setting a response handler for requestId {meshPacket.id}")
             self._addResponseHandler(meshPacket.id, onResponse, ackPermitted=onResponseAckPermitted)
-        p = self._sendPacket(meshPacket, destinationId, wantAck=wantAck)
+        p = self._sendPacket(meshPacket, destinationId, wantAck=wantAck, hopLimit=hopLimit)
         return p
 
     def sendPosition(
@@ -478,6 +480,7 @@ class MeshInterface: # pylint: disable=R0902
             wantResponse=True,
             onResponse=self.onResponseTraceRoute,
             channelIndex=channelIndex,
+            hopLimit=hopLimit,
         )
         # extend timeout based on number of nodes, limit by configured hopLimit
         waitFactor = min(len(self.nodes) - 1 if self.nodes else 0, hopLimit)
@@ -563,7 +566,7 @@ class MeshInterface: # pylint: disable=R0902
     def _addResponseHandler(self, requestId: int, callback: Callable[[dict], Any], ackPermitted: bool=False):
         self.responseHandlers[requestId] = ResponseHandler(callback=callback, ackPermitted=ackPermitted)
 
-    def _sendPacket(self, meshPacket: mesh_pb2.MeshPacket, destinationId: Union[int,str]=BROADCAST_ADDR, wantAck: bool=False):
+    def _sendPacket(self, meshPacket: mesh_pb2.MeshPacket, destinationId: Union[int,str]=BROADCAST_ADDR, wantAck: bool=False, hopLimit: Optional[int]=None):
         """Send a MeshPacket to the specified node (or if unspecified, broadcast).
         You probably don't want this - use sendData instead.
 
@@ -604,9 +607,12 @@ class MeshInterface: # pylint: disable=R0902
 
         meshPacket.to = nodeNum
         meshPacket.want_ack = wantAck
-        loraConfig = getattr(self.localNode.localConfig, "lora")
-        hopLimit = getattr(loraConfig, "hop_limit")
-        meshPacket.hop_limit = hopLimit
+
+        if hopLimit is not None:
+            meshPacket.hop_limit = hopLimit
+        else:
+            loraConfig = getattr(self.localNode.localConfig, "lora")
+            meshPacket.hop_limit = getattr(loraConfig, "hop_limit")
 
         # if the user hasn't set an ID for this packet (likely and recommended),
         # we should pick a new unique ID so the message can be tracked.


### PR DESCRIPTION
If you use:
```
interface.sendTraceRoute(dest="!3b46b95d", hopLimit=5)
```

The `hopLimit` param specified is not used for the trace route as expected, the lora config `hopLimit` is used. This fix allows trace routes to be sent with a dynamic hop limit as the `sendTraceRoute` method definition would lead you to believe is possible.