### PR TITLE
JSON format for the _handlePacketFromRadio handler

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -1135,7 +1135,7 @@ class MeshInterface: # pylint: disable=R0902
         # We normally decompose the payload into a dictionary so that the client
         # doesn't need to understand protobufs.  But advanced clients might
         # want the raw protobuf, so we provide it in "raw"
-        asDict["raw"] = meshPacket
+        asDict["raw"] = stripnl(meshPacket)
 
         # from might be missing if the nodenum was zero.
         if not hack and "from" not in asDict:
@@ -1201,7 +1201,7 @@ class MeshInterface: # pylint: disable=R0902
                     p = google.protobuf.json_format.MessageToDict(pb)
                     asDict["decoded"][handler.name] = p
                     # Also provide the protobuf raw
-                    asDict["decoded"][handler.name]["raw"] = pb
+                    asDict["decoded"][handler.name]["raw"] = stripnl(pb)
 
                 # Call specialized onReceive if necessary
                 if handler.onReceive is not None:
@@ -1225,6 +1225,7 @@ class MeshInterface: # pylint: disable=R0902
                         handler.callback(asDict)
 
         logging.debug(f"Publishing {topic}: packet={stripnl(asDict)} ")
+        asDictJson = json.dumps(asDict, indent=2, default=str)
         publishingThread.queueWork(
-            lambda: pub.sendMessage(topic, packet=asDict, interface=self)
+            lambda: pub.sendMessage(topic, packet=asDictJson, interface=self)
         )


### PR DESCRIPTION
This PR converts the asDict output into JSON format.

I've used the following code to test this output:

```import meshtastic.serial_interface
from pubsub import pub
interface = meshtastic.serial_interface.SerialInterface()
def onReceive(packet, interface):
    print(f"{packet} \n\n") 
pub.subscribe(onReceive, 'meshtastic.receive')
while True:
    pass
```
    
The current library outputs packets formatted like this:

```
{'from': 1828778968, 'to': 4294967295, 'decoded': {'portnum': 'TELEMETRY_APP', 'payload': b'\r)\xd6\xaff\x12\x14\x08e\x15\xd9\xce\x87@\x1dH\xe14A%\x91\xa1|@(\xbeB', 'telemetry': {'time': 1722799657, 'deviceMetrics': {'batteryLevel': 101, 'voltage': 4.244, 'channelUtilization': 11.305, 'airUtilTx': 3.9473612, 'uptimeSeconds': 8510}, 'raw': time: 1722799657
device_metrics {
  battery_level: 101
  voltage: 4.244
  channel_utilization: 11.305
  air_util_tx: 3.94736123
  uptime_seconds: 8510
}
}}, 'id': 1848567030, 'rxTime': 1722799657, 'hopLimit': 3, 'priority': 'BACKGROUND', 'raw': from: 1828778968
to: 4294967295
decoded {
  portnum: TELEMETRY_APP
  payload: "\r)\326\257f\022\024\010e\025\331\316\207@\035H\3414A%\221\241|@(\276B"
}
id: 1848567030
rx_time: 1722799657
hop_limit: 3
priority: BACKGROUND
, 'fromId': '!6d00f3d8', 'toId': '^all'} 
```

This PR changes the output to look like this:

```
{
  "from": 3663889336,
  "to": 4294967295,
  "decoded": {
    "portnum": "TELEMETRY_APP",
    "payload": "b'\\rj\\xd6\\xaff\\x12\\x15\\x08R\\x15\\xf6(\\x80@\\x1d\\xfa\\xc5\\xc4A%\\x05\\xa2\\xd3@(\\xff\\xe5\\x1a'",
    "telemetry": {
      "time": 1722799722,
      "deviceMetrics": {
        "batteryLevel": 82,
        "voltage": 4.005,
        "channelUtilization": 24.596668,
        "airUtilTx": 6.613528,
        "uptimeSeconds": 439039
      },
      "raw": "time: 1722799722 device_metrics { battery_level: 82 voltage: 4.005 channel_utilization: 24.5966682 air_util_tx: 6.61352777 uptime_seconds: 439039 }"
    }
  },
  "id": 1923380448,
  "rxTime": 1722799742,
  "rxSnr": 10.25,
  "hopLimit": 5,
  "rxRssi": -62,
  "hopStart": 7,
  "raw": "from: 3663889336 to: 4294967295 decoded { portnum: TELEMETRY_APP payload: \"\\rj\\326\\257f\\022\\025\\010R\\025\\366(\\200@\\035\\372\\305\\304A%\\005\\242\\323@(\\377\\345\\032\" } id: 1923380448 rx_time: 1722799742 rx_snr: 10.25 hop_limit: 5 rx_rssi: -62 hop_start: 7",
  "fromId": "!da6283b8",
  "toId": "^all"
} 
```
