### PR TITLE
randomize packet IDs as firmware does

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -802,7 +802,10 @@ class MeshInterface:  # pylint: disable=R0902
                 "Not connected yet, can not generate packet"
             )
         else:
-            self.currentPacketId = (self.currentPacketId + 1) & 0xFFFFFFFF
+            nextPacketId = (self.currentPacketId + 1) & 0xFFFFFFFF
+            nextPacketId = nextPacketId & (0xFFFFFFFF >> 22)             # mask upper 22 bits
+            randomPart = (random.randint(0, 0x7FFFFFFF) << 10) & 0xFFFFFFFF # generate number with 10 zeros at end
+            self.currentPacketId = nextPacketId | randomPart             # combine
             return self.currentPacketId
 
     def _disconnected(self):


### PR DESCRIPTION
I _think_ this should match. I'm not sure if we're supposed to match the firmware's packet IDs in any way, or if it's fine that the client and the firmware-sent packets have a different sequence being used.