### PR TITLE
Don't automatically set the time from Python

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -442,7 +442,6 @@ class MeshInterface:  # pylint: disable=R0902
         latitude: float = 0.0,
         longitude: float = 0.0,
         altitude: int = 0,
-        timeSec: int = 0,
         destinationId: Union[int, str] = BROADCAST_ADDR,
         wantAck: bool = False,
         wantResponse: bool = False,
@@ -453,8 +452,6 @@ class MeshInterface:  # pylint: disable=R0902
 
         Also, the device software will notice this packet and use it to automatically
         set its notion of the local position.
-
-        If timeSec is not specified (recommended), we will use the local machine time.
 
         Returns the sent packet. The id field will be populated in this packet and
         can be used to track future message acks/naks.

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -472,11 +472,6 @@ class MeshInterface:  # pylint: disable=R0902
             p.altitude = int(altitude)
             logging.debug(f"p.altitude:{p.altitude}")
 
-        if timeSec == 0:
-            timeSec = int(time.time())  # returns unix timestamp in seconds
-        p.time = timeSec
-        logging.debug(f"p.time:{p.time}")
-
         if wantResponse:
             onResponse = self.onResponsePosition
         else:

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -185,7 +185,7 @@ def test_sendPosition(caplog):
     with caplog.at_level(logging.DEBUG):
         iface.sendPosition()
     iface.close()
-    assert re.search(r"p.time:", caplog.text, re.MULTILINE)
+    # assert re.search(r"p.time:", caplog.text, re.MULTILINE)
 
 
 # TODO


### PR DESCRIPTION
The Python MO is to do as little as possible beyond what the user has intentionally instructed. So don't try to set the time automatically.