### PR TITLE
Reuse node to prevent overwriting channel settings

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -778,7 +778,8 @@ def onConnected(interface):
             channelIndex = mt_config.channel_index
             if channelIndex is None:
                 meshtastic.util.our_exit("Warning: Need to specify '--ch-index'.", 1)
-            ch = interface.getNode(args.dest).channels[channelIndex]
+            node = interface.getNode(args.dest)
+            ch = node.channels[channelIndex]
 
             if args.ch_enable or args.ch_disable:
                 print(
@@ -836,7 +837,7 @@ def onConnected(interface):
                 ch.role = channel_pb2.Channel.Role.DISABLED
 
             print(f"Writing modified channels to device")
-            interface.getNode(args.dest).writeChannel(channelIndex)
+            node.writeChannel(channelIndex)
 
         if args.get_canned_message:
             closeNow = True


### PR DESCRIPTION
Hi!

I noticed that I'm unable to use any `--ch-set` settings over the admin channel (using `--dest`). The core issue is that the repeated use of `interface.getNode` fetches all the channels again, overwriting the channels on the node object that had just been retrieved and updated to change the appropriate settings. This means that `downlink_enabled`, `uplink_enabled`, and so on couldn't actually be updated using remote admin. I've confirmed this change allowed me to change MQTT uplink/downlink on a remote node on a tall rooftop.

I attempted to use `requestChannels` in `getNode` but the repeated usage of `getNode` itself blows away the channels on the object, regardless.