### PR TITLE
Allow port number to be specified with tcp hostname

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1159,7 +1159,7 @@ def common():
                         tcp_hostname, tcp_port = args.host.split(':')
                     else:
                         tcp_hostname = args.host
-                        tcp_port = 4403
+                        tcp_port = meshtastic.tcp_interface.DEFAULT_TCP_PORT
                     client = meshtastic.tcp_interface.TCPInterface(
                         tcp_hostname,
                         portNumber=tcp_port,

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1155,8 +1155,14 @@ def common():
                 )
             elif args.host:
                 try:
+                    if ":" in args.host:
+                        tcp_hostname, tcp_port = args.host.split(':')
+                    else:
+                        tcp_hostname = args.host
+                        tcp_port = 4403
                     client = meshtastic.tcp_interface.TCPInterface(
-                        args.host,
+                        tcp_hostname,
+                        portNumber=tcp_port,
                         debugOut=logfile,
                         noProto=args.noproto,
                         noNodes=args.no_nodes,

--- a/meshtastic/tcp_interface.py
+++ b/meshtastic/tcp_interface.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from meshtastic.stream_interface import StreamInterface
 
+DEFAULT_TCP_PORT = 4403
 
 class TCPInterface(StreamInterface):
     """Interface class for meshtastic devices over a TCP link"""
@@ -16,7 +17,7 @@ class TCPInterface(StreamInterface):
         debugOut=None,
         noProto=False,
         connectNow=True,
-        portNumber=4403,
+        portNumber=DEFAULT_TCP_PORT,
         noNodes:bool=False,
     ):
         """Constructor, opens a connection to a specified IP address/hostname


### PR DESCRIPTION
This is minor but useful when a different port number needs to be specified (when tunneling over SSH, for example).