### PR TITLE
Add a --set-time command that set's the node time using a provided timestamp or the host system clock

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -285,6 +285,9 @@ def onConnected(interface):
         if not args.export_config:
             print("Connected to radio")
 
+        if args.set_time is not None:
+            interface.getNode(args.dest, False, **getNode_kwargs).setTime(args.set_time)
+
         if args.remove_position:
             closeNow = True
             waitForAckNak = True
@@ -1595,6 +1598,16 @@ def initParser():
         "--reset-nodedb",
         help="Tell the destination node to clear its list of nodes",
         action="store_true",
+    )
+
+    group.add_argument(
+        "--set-time",
+        help="Set the time to the provided unix epoch timestamp, or the system's current time if omitted or 0.",
+        action="store",
+        type=int,
+        nargs="?",
+        default=None,
+        const=0,
     )
 
     group.add_argument(

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -722,6 +722,21 @@ class Node:
             onResponse = self.onAckNak
         return self._sendAdmin(p, onResponse=onResponse)
 
+    def setTime(self, timeSec: int = 0):
+        """Tell the node to set its time to the provided timestamp, or the system's current time if not provided or 0."""
+        self.ensureSessionKey()
+        if timeSec == 0:
+            timeSec = int(time.time())
+        p = admin_pb2.AdminMessage()
+        p.set_time_only = timeSec
+        logging.info(f"Setting node time to {timeSec}")
+
+        if self == self.iface.localNode:
+            onResponse = None
+        else:
+            onResponse = self.onAckNak
+        return self._sendAdmin(p, onResponse=onResponse)
+
     def _fixupChannels(self):
         """Fixup indexes and add disabled channels as needed"""
 


### PR DESCRIPTION
Now that time isn't set by default and there's an admin message for this, we should be using it/allowing it. Bonus, this allows setting remote node time if I understand it correctly!

ref: meshtastic/firmware#4479