### PR TITLE
Add a number of argument groups to organize the help output

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1228,7 +1228,7 @@ def common():
 
 
 def addConnectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    """Add connection specifiation arguments"""
+    """Add connection specification arguments"""
 
     outer = parser.add_argument_group(
         "Connection",
@@ -1264,96 +1264,61 @@ def addConnectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParse
         const="any",
     )
 
+    outer.add_argument(
+        "--ble-scan",
+        help="Scan for Meshtastic BLE devices that may be available to connect to",
+        action="store_true",
+    )
+
     return parser
 
-
-def initParser():
-    """Initialize the command line argument parsing."""
-    parser = mt_config.parser
-    args = mt_config.args
-
-    # The "Help" group includes the help option and other informational stuff about the CLI itself
-    outerHelpGroup = parser.add_argument_group("Help")
-    helpGroup = outerHelpGroup.add_mutually_exclusive_group()
-    helpGroup.add_argument(
-        "-h", "--help", action="help", help="show this help message and exit"
+def addSelectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add node/channel specification arguments"""
+    group = parser.add_argument_group(
+        "Selection",
+        "Arguments that select channels to use, destination nodes, etc."
     )
 
-    the_version = get_active_version()
-    helpGroup.add_argument("--version", action="version", version=f"{the_version}")
-
-    helpGroup.add_argument(
-        "--support",
-        action="store_true",
-        help="Show support info (useful when troubleshooting an issue)",
+    group.add_argument(
+        "--dest",
+        help="The destination node id for any sent commands, if not set '^all' or '^local' is assumed as appropriate",
+        default=None,
+        metavar="!xxxxxxxx",
     )
 
-    # Connection arguments to indicate a device to connect to
-    parser = addConnectionArgs(parser)
+    group.add_argument(
+        "--ch-index",
+        help="Set the specified channel index for channel-specific commands. Channels start at 0 (0 is the PRIMARY channel).",
+        action="store",
+    )
 
-    # Arguments concerning viewing and setting configuration
+    return parser
 
-    # Arguments for sending or requesting things from the local device
+def addImportExportArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add import/export config arguments"""
+    group = parser.add_argument_group(
+        "Import/Export",
+        "Arguments that concern importing and exporting configuration of Meshtastic devices",
+    )
 
-    # Arguments for sending or requesting things from the mesh
-
-    # All the rest of the arguments
-    group = parser.add_argument_group("optional arguments")
     group.add_argument(
         "--configure",
         help="Specify a path to a yaml(.yml) file containing the desired settings for the connected device.",
         action="append",
     )
-
     group.add_argument(
         "--export-config",
         help="Export the configuration in yaml(.yml) format.",
         action="store_true",
     )
+    return parser
 
-    group.add_argument(
-        "--seriallog",
-        help="Log device serial output to either 'none' or a filename to append to.  Defaults to 'stdout' if no filename specified.",
-        nargs="?",
-        const="stdout",
-        default=None,
-    )
+def addConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add arguments to do with configuring a device"""
 
-    group.add_argument(
-        "--info",
-        help="Read and display the radio config information",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--get-canned-message",
-        help="Show the canned message plugin message",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--get-ringtone", help="Show the stored ringtone", action="store_true"
-    )
-
-    group.add_argument(
-        "--nodes",
-        help="Print Node List in a pretty formatted table",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--qr",
-        help=(
-            "Display a QR code for the node's primary channel (or all channels with --qr-all). "
-            "Also shows the shareable channel URL."
-        ),
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--qr-all",
-        help="Display a QR code and URL for all of the node's channels.",
-        action="store_true",
+    group = parser.add_argument_group(
+        "Configuration",
+        "Arguments that concern general configuration of Meshtastic devices",
     )
 
     group.add_argument(
@@ -1373,12 +1338,102 @@ def initParser():
         action="append",
     )
 
-    group.add_argument("--seturl", help="Set a channel URL", action="store")
+    group.add_argument(
+        "--begin-edit",
+        help="Tell the node to open a transaction to edit settings",
+        action="store_true",
+    )
 
     group.add_argument(
-        "--ch-index",
-        help="Set the specified channel index. Channels start at 0 (0 is the PRIMARY channel).",
+        "--commit-edit",
+        help="Tell the node to commit open settings transaction",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--get-canned-message",
+        help="Show the canned message plugin message",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--set-canned-message",
+        help="Set the canned messages plugin message (up to 200 characters).",
         action="store",
+    )
+
+    group.add_argument(
+        "--get-ringtone", help="Show the stored ringtone", action="store_true"
+    )
+
+    group.add_argument(
+        "--set-ringtone",
+        help="Set the Notification Ringtone (up to 230 characters).",
+        action="store",
+    )
+
+    group.add_argument(
+        "--ch-vlongslow",
+        help="Change to the very long-range and slow modem preset",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--ch-longslow",
+        help="Change to the long-range and slow modem preset",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--ch-longfast",
+        help="Change to the long-range and fast modem preset",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--ch-medslow",
+        help="Change to the med-range and slow modem preset",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--ch-medfast",
+        help="Change to the med-range and fast modem preset",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--ch-shortslow",
+        help="Change to the short-range and slow modem preset",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--ch-shortfast",
+        help="Change to the short-range and fast modem preset",
+        action="store_true",
+    )
+
+    group.add_argument("--set-owner", help="Set device owner name", action="store")
+
+    group.add_argument(
+        "--set-owner-short", help="Set device owner short name", action="store"
+    )
+
+    group.add_argument(
+        "--set-ham", help="Set licensed Ham ID and turn off encryption", action="store"
+    )
+
+    group.add_argument("--seturl", help="Set a channel URL", action="store")
+
+    return parser
+
+def addChannelConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add arguments to do with configuring channels"""
+
+    group = parser.add_argument_group(
+        "Channel Configuration",
+        "Arguments that concern configuration of channels",
     )
 
     group.add_argument(
@@ -1389,23 +1444,6 @@ def initParser():
 
     group.add_argument(
         "--ch-del", help="Delete the ch-index channel", action="store_true"
-    )
-
-    group.add_argument(
-        "--ch-enable",
-        help="Enable the specified channel",
-        action="store_true",
-        dest="ch_enable",
-        default=False,
-    )
-
-    # Note: We are doing a double negative here (Do we want to disable? If ch_disable==True, then disable.)
-    group.add_argument(
-        "--ch-disable",
-        help="Disable the specified channel",
-        action="store_true",
-        dest="ch_disable",
-        default=False,
     )
 
     group.add_argument(
@@ -1423,210 +1461,52 @@ def initParser():
 
     group.add_argument(
         "--channel-fetch-attempts",
-        help=("Attempt to retrieve channel settings for --ch-set this many times before giving up."),
+        help=("Attempt to retrieve channel settings for --ch-set this many times before giving up. Default %(default)s."),
         default=3,
         type=int,
     )
 
     group.add_argument(
-        "--timeout",
-        help="How long to wait for replies",
-        default=300,
-        type=int,
-    )
-
-    group.add_argument(
-        "--ch-vlongslow",
-        help="Change to the very long-range and slow channel",
+        "--qr",
+        help=(
+            "Display a QR code for the node's primary channel (or all channels with --qr-all). "
+            "Also shows the shareable channel URL."
+        ),
         action="store_true",
     )
 
     group.add_argument(
-        "--ch-longslow",
-        help="Change to the long-range and slow channel",
+        "--qr-all",
+        help="Display a QR code and URL for all of the node's channels.",
         action="store_true",
     )
 
     group.add_argument(
-        "--ch-longfast",
-        help="Change to the long-range and fast channel",
+        "--ch-enable",
+        help="Enable the specified channel. Use --ch-add instead whenever possible.",
         action="store_true",
+        dest="ch_enable",
+        default=False,
     )
 
+    # Note: We are doing a double negative here (Do we want to disable? If ch_disable==True, then disable.)
     group.add_argument(
-        "--ch-medslow",
-        help="Change to the med-range and slow channel",
+        "--ch-disable",
+        help="Disable the specified channel Use --ch-del instead whenever possible.",
         action="store_true",
+        dest="ch_disable",
+        default=False,
     )
 
-    group.add_argument(
-        "--ch-medfast",
-        help="Change to the med-range and fast channel",
-        action="store_true",
-    )
+    return parser
 
-    group.add_argument(
-        "--ch-shortslow",
-        help="Change to the short-range and slow channel",
-        action="store_true",
-    )
+def addPositionConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add arguments to do with fixed positions and position config"""
 
-    group.add_argument(
-        "--ch-shortfast",
-        help="Change to the short-range and fast channel",
-        action="store_true",
+    group = parser.add_argument_group(
+        "Position Configuration",
+        "Arguments that modify fixed position and other position-related configuration.",
     )
-
-    group.add_argument("--set-owner", help="Set device owner name", action="store")
-
-    group.add_argument(
-        "--set-owner-short", help="Set device owner short name", action="store"
-    )
-
-    group.add_argument(
-        "--set-canned-message",
-        help="Set the canned messages plugin message (up to 200 characters).",
-        action="store",
-    )
-
-    group.add_argument(
-        "--set-ringtone",
-        help="Set the Notification Ringtone (up to 230 characters).",
-        action="store",
-    )
-
-    group.add_argument(
-        "--set-ham", help="Set licensed Ham ID and turn off encryption", action="store"
-    )
-
-    group.add_argument(
-        "--dest",
-        help="The destination node id for any sent commands, if not set '^all' or '^local' is assumed as appropriate",
-        default=None,
-    )
-
-    group.add_argument(
-        "--sendtext",
-        help="Send a text message. Can specify a destination '--dest' and/or channel index '--ch-index'.",
-    )
-
-    group.add_argument(
-        "--traceroute",
-        help="Traceroute from connected node to a destination. "
-        "You need pass the destination ID as argument, like "
-        "this: '--traceroute !ba4bf9d0' "
-        "Only nodes that have the encryption key can be traced.",
-    )
-
-    group.add_argument(
-        "--request-telemetry",
-        help="Request telemetry from a node. "
-        "You need to pass the destination ID as argument with '--dest'. "
-        "For repeaters, the nodeNum is required.",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--request-position",
-        help="Request the position from a node. "
-        "You need to pass the destination ID as an argument with '--dest'. "
-        "For repeaters, the nodeNum is required.",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--ack",
-        help="Use in combination with --sendtext to wait for an acknowledgment.",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--reboot", help="Tell the destination node to reboot", action="store_true"
-    )
-
-    group.add_argument(
-        "--reboot-ota",
-        help="Tell the destination node to reboot into factory firmware (ESP32)",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--enter-dfu",
-        help="Tell the destination node to enter DFU mode (NRF52)",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--shutdown", help="Tell the destination node to shutdown", action="store_true"
-    )
-
-    group.add_argument(
-        "--device-metadata",
-        help="Get the device metadata from the node",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--begin-edit",
-        help="Tell the node to open a transaction to edit settings",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--commit-edit",
-        help="Tell the node to commit open settings transaction",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--factory-reset", "--factory-reset-config",
-        help="Tell the destination node to install the default config, preserving BLE bonds & PKI keys",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--factory-reset-device",
-        help="Tell the destination node to install the default config and clear BLE bonds & PKI keys",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--remove-node",
-        help="Tell the destination node to remove a specific node from its DB, by node number or ID",
-    )
-    group.add_argument(
-        "--reset-nodedb",
-        help="Tell the destination node to clear its list of nodes",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--set-time",
-        help="Set the time to the provided unix epoch timestamp, or the system's current time if omitted or 0.",
-        action="store",
-        type=int,
-        nargs="?",
-        default=None,
-        const=0,
-    )
-
-    group.add_argument(
-        "--reply", help="Reply to received messages", action="store_true"
-    )
-
-    group.add_argument(
-        "--no-time",
-        help="Deprecated. Retained for backwards compatibility in scripts, but is a no-op.",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--no-nodes",
-        help="Request that the node not send node info to the client. "
-        "Will break things that depend on the nodedb, but will speed up startup. Requires 2.3.11+ firmware.",
-        action="store_true",
-    )
-
     group.add_argument(
         "--setalt",
         help="Set device altitude in meters (allows use without GPS), and enable fixed position. "
@@ -1659,6 +1539,215 @@ def initParser():
         nargs="*",
         action="store",
     )
+    return parser
+
+def addLocalActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add arguments concerning local-only information & actions"""
+    group = parser.add_argument_group(
+        "Local Actions",
+        "Arguments that take actions or request information from the local node only.",
+    )
+
+    group.add_argument(
+        "--info",
+        help="Read and display the radio config information",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--nodes",
+        help="Print Node List in a pretty formatted table",
+        action="store_true",
+    )
+
+    return parser
+
+def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add arguments concerning information & actions that may interact with the mesh"""
+    group = parser.add_argument_group(
+        "Remote Actions",
+        "Arguments that take actions or request information from either the local node or remote nodes via the mesh.",
+    )
+
+    group.add_argument(
+        "--sendtext",
+        help="Send a text message. Can specify a destination '--dest' and/or channel index '--ch-index'.",
+    )
+
+    group.add_argument(
+        "--traceroute",
+        help="Traceroute from connected node to a destination. "
+        "You need pass the destination ID as argument, like "
+        "this: '--traceroute !ba4bf9d0' "
+        "Only nodes that have the encryption key can be traced.",
+    )
+
+    group.add_argument(
+        "--request-telemetry",
+        help="Request telemetry from a node. "
+        "You need to pass the destination ID as argument with '--dest'. "
+        "For repeaters, the nodeNum is required.",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--request-position",
+        help="Request the position from a node. "
+        "You need to pass the destination ID as an argument with '--dest'. "
+        "For repeaters, the nodeNum is required.",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--reply", help="Reply to received messages", action="store_true"
+    )
+
+    return parser
+
+def addRemoteAdminArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add arguments concerning admin actions that may interact with the mesh"""
+
+    outer = parser.add_argument_group(
+        "Remote Admin Actions",
+        "Arguments that interact with local node or remote nodes via the mesh, requiring admin access.",
+    )
+
+    group = outer.add_mutually_exclusive_group()
+
+    group.add_argument(
+        "--reboot", help="Tell the destination node to reboot", action="store_true"
+    )
+
+    group.add_argument(
+        "--reboot-ota",
+        help="Tell the destination node to reboot into factory firmware (ESP32)",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--enter-dfu",
+        help="Tell the destination node to enter DFU mode (NRF52)",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--shutdown", help="Tell the destination node to shutdown", action="store_true"
+    )
+
+    group.add_argument(
+        "--device-metadata",
+        help="Get the device metadata from the node",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--factory-reset", "--factory-reset-config",
+        help="Tell the destination node to install the default config, preserving BLE bonds & PKI keys",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--factory-reset-device",
+        help="Tell the destination node to install the default config and clear BLE bonds & PKI keys",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--remove-node",
+        help="Tell the destination node to remove a specific node from its DB, by node number or ID",
+        metavar="!xxxxxxxx"
+    )
+    group.add_argument(
+        "--reset-nodedb",
+        help="Tell the destination node to clear its list of nodes",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--set-time",
+        help="Set the time to the provided unix epoch timestamp, or the system's current time if omitted or 0.",
+        action="store",
+        type=int,
+        nargs="?",
+        default=None,
+        const=0,
+        metavar="TIMESTAMP",
+    )
+
+    return parser
+
+def initParser():
+    """Initialize the command line argument parsing."""
+    parser = mt_config.parser
+    args = mt_config.args
+
+    # The "Help" group includes the help option and other informational stuff about the CLI itself
+    outerHelpGroup = parser.add_argument_group("Help")
+    helpGroup = outerHelpGroup.add_mutually_exclusive_group()
+    helpGroup.add_argument(
+        "-h", "--help", action="help", help="show this help message and exit"
+    )
+
+    the_version = get_active_version()
+    helpGroup.add_argument("--version", action="version", version=f"{the_version}")
+
+    helpGroup.add_argument(
+        "--support",
+        action="store_true",
+        help="Show support info (useful when troubleshooting an issue)",
+    )
+
+    # Connection arguments to indicate a device to connect to
+    parser = addConnectionArgs(parser)
+
+    # Selection arguments to denote nodes and channels to use
+    parser = addSelectionArgs(parser)
+
+    # Arguments concerning viewing and setting configuration
+    parser = addImportExportArgs(parser)
+    parser = addConfigArgs(parser)
+    parser = addPositionConfigArgs(parser)
+    parser = addChannelConfigArgs(parser)
+
+    # Arguments for sending or requesting things from the local device
+    parser = addLocalActionArgs(parser)
+
+    # Arguments for sending or requesting things from the mesh
+    parser = addRemoteActionArgs(parser)
+    parser = addRemoteAdminArgs(parser)
+
+    # All the rest of the arguments
+    group = parser.add_argument_group("Miscellaneous arguments")
+
+    group.add_argument(
+        "--seriallog",
+        help="Log device serial output to either 'none' or a filename to append to.  Defaults to '%(const)s' if no filename specified.",
+        nargs="?",
+        const="stdout",
+        default=None,
+        metavar="LOG_DESTINATION",
+    )
+
+    group.add_argument(
+        "--ack",
+        help="Use in combination with compatible actions (e.g. --sendtext) to wait for an acknowledgment.",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--timeout",
+        help="How long to wait for replies. Default %(default)ss.",
+        default=300,
+        type=int,
+        metavar="SECONDS",
+    )
+
+    group.add_argument(
+        "--no-nodes",
+        help="Request that the node not send node info to the client. "
+        "Will break things that depend on the nodedb, but will speed up startup. Requires 2.3.11+ firmware.",
+        action="store_true",
+    )
 
     group.add_argument(
         "--debug", help="Show API library debug log messages", action="store_true"
@@ -1667,6 +1756,33 @@ def initParser():
     group.add_argument(
         "--test",
         help="Run stress test against all connected Meshtastic devices",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--wait-to-disconnect",
+        help="How many seconds to wait before disconnecting from the device.",
+        const="5",
+        nargs="?",
+        action="store",
+        metavar="SECONDS",
+    )
+
+    group.add_argument(
+        "--noproto",
+        help="Don't start the API, just function as a dumb serial terminal.",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--listen",
+        help="Just stay open and listen to the protobuf stream. Enables debug logging.",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--no-time",
+        help="Deprecated. Retained for backwards compatibility in scripts, but is a no-op.",
         action="store_true",
     )
 
@@ -1724,31 +1840,6 @@ def initParser():
         const="default",
     )
 
-    group.add_argument(
-        "--ble-scan",
-        help="Scan for Meshtastic BLE devices",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--wait-to-disconnect",
-        help="How many seconds to wait before disconnecting from the device.",
-        const="5",
-        nargs="?",
-        action="store",
-    )
-
-    group.add_argument(
-        "--noproto",
-        help="Don't start the API, just function as a dumb serial terminal.",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--listen",
-        help="Just stay open and listen to the protobuf stream. Enables debug logging.",
-        action="store_true",
-    )
 
     remoteHardwareArgs = parser.add_argument_group(
         "Remote Hardware", "Arguments related to the Remote Hardware module"

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1290,6 +1290,7 @@ def addSelectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         "--ch-index",
         help="Set the specified channel index for channel-specific commands. Channels start at 0 (0 is the PRIMARY channel).",
         action="store",
+        metavar="INDEX",
     )
 
     return parser
@@ -1329,6 +1330,7 @@ def addConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         ),
         nargs=1,
         action="append",
+        metavar="FIELD"
     )
 
     group.add_argument(
@@ -1336,6 +1338,7 @@ def addConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         help="Set a preferences field. Can use either snake_case or camelCase format. (ex: 'ls_secs' or 'lsSecs')",
         nargs=2,
         action="append",
+        metavar=("FIELD", "VALUE"),
     )
 
     group.add_argument(
@@ -1370,6 +1373,7 @@ def addConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "--set-ringtone",
         help="Set the Notification Ringtone (up to 230 characters).",
         action="store",
+        metavar="RINGTONE",
     )
 
     group.add_argument(
@@ -1457,6 +1461,7 @@ def addChannelConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
         ),
         nargs=2,
         action="append",
+        metavar=("FIELD", "VALUE"),
     )
 
     group.add_argument(
@@ -1464,6 +1469,7 @@ def addChannelConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
         help=("Attempt to retrieve channel settings for --ch-set this many times before giving up. Default %(default)s."),
         default=3,
         type=int,
+        metavar="ATTEMPTS",
     )
 
     group.add_argument(
@@ -1572,6 +1578,7 @@ def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
     group.add_argument(
         "--sendtext",
         help="Send a text message. Can specify a destination '--dest' and/or channel index '--ch-index'.",
+        metavar="TEXT",
     )
 
     group.add_argument(
@@ -1579,7 +1586,8 @@ def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
         help="Traceroute from connected node to a destination. "
         "You need pass the destination ID as argument, like "
         "this: '--traceroute !ba4bf9d0' "
-        "Only nodes that have the encryption key can be traced.",
+        "Only nodes with a shared channel can be traced.",
+        metavar="!xxxxxxxx",
     )
 
     group.add_argument(


### PR DESCRIPTION
Largely just rearranges, but I did also update a couple of argument descriptions, metavars, that sort of thing. The help output with these changes:

```
usage: meshtastic [-h | --version | --support] [--port [PORT] | --host [HOST] | --ble [BLE]] [--ble-scan] [--dest !xxxxxxxx] [--ch-index CH_INDEX]
                  [--configure CONFIGURE] [--export-config] [--get GET] [--set SET SET] [--begin-edit] [--commit-edit] [--get-canned-message]
                  [--set-canned-message SET_CANNED_MESSAGE] [--get-ringtone] [--set-ringtone SET_RINGTONE] [--ch-vlongslow] [--ch-longslow] [--ch-longfast]
                  [--ch-medslow] [--ch-medfast] [--ch-shortslow] [--ch-shortfast] [--set-owner SET_OWNER] [--set-owner-short SET_OWNER_SHORT] [--set-ham SET_HAM]
                  [--seturl SETURL] [--setalt SETALT] [--setlat SETLAT] [--setlon SETLON] [--remove-position] [--pos-fields [POS_FIELDS ...]] [--ch-add CH_ADD]
                  [--ch-del] [--ch-set CH_SET CH_SET] [--channel-fetch-attempts CHANNEL_FETCH_ATTEMPTS] [--qr] [--qr-all] [--ch-enable] [--ch-disable] [--info]
                  [--nodes] [--sendtext SENDTEXT] [--traceroute TRACEROUTE] [--request-telemetry] [--request-position] [--reply]
                  [--reboot | --reboot-ota | --enter-dfu | --shutdown | --device-metadata | --factory-reset | --factory-reset-device | --remove-node !xxxxxxxx | --reset-nodedb | --set-time [TIMESTAMP]]
                  [--seriallog [LOG_DESTINATION]] [--ack] [--timeout SECONDS] [--no-nodes] [--debug] [--test] [--wait-to-disconnect [SECONDS]] [--noproto]
                  [--listen] [--no-time] [--power-riden POWER_RIDEN | --power-ppk2-meter | --power-ppk2-supply | --power-sim] [--power-voltage POWER_VOLTAGE]
                  [--power-stress] [--power-wait] [--slog [SLOG]] [--gpio-wrb GPIO_WRB GPIO_WRB] [--gpio-rd GPIO_RD] [--gpio-watch GPIO_WATCH] [--tunnel]
                  [--subnet TUNNEL_NET]

Help:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  --support             Show support info (useful when troubleshooting an issue)

Connection:
  Optional arguments that specify how to connect to a Meshtastic device.

  --port [PORT], --serial [PORT], -s [PORT]
                        The port of the device to connect to using serial, e.g. /dev/ttyUSB0. (defaults to trying to detect a port)
  --host [HOST], --tcp [HOST], -t [HOST]
                        Connect to a device using TCP, optionally passing hostname or IP address to use. (defaults to 'localhost')
  --ble [BLE], -b [BLE]
                        Connect to a BLE device, optionally specifying a device name (defaults to 'any')
  --ble-scan            Scan for Meshtastic BLE devices that may be available to connect to

Selection:
  Arguments that select channels to use, destination nodes, etc.

  --dest !xxxxxxxx      The destination node id for any sent commands, if not set '^all' or '^local' is assumed as appropriate
  --ch-index CH_INDEX   Set the specified channel index for channel-specific commands. Channels start at 0 (0 is the PRIMARY channel).

Import/Export:
  Arguments that concern importing and exporting configuration of Meshtastic devices

  --configure CONFIGURE
                        Specify a path to a yaml(.yml) file containing the desired settings for the connected device.
  --export-config       Export the configuration in yaml(.yml) format.

Configuration:
  Arguments that concern general configuration of Meshtastic devices

  --get GET             Get a preferences field. Use an invalid field such as '0' to get a list of all fields. Can use either snake_case or camelCase format.
                        (ex: 'ls_secs' or 'lsSecs')
  --set SET SET         Set a preferences field. Can use either snake_case or camelCase format. (ex: 'ls_secs' or 'lsSecs')
  --begin-edit          Tell the node to open a transaction to edit settings
  --commit-edit         Tell the node to commit open settings transaction
  --get-canned-message  Show the canned message plugin message
  --set-canned-message SET_CANNED_MESSAGE
                        Set the canned messages plugin message (up to 200 characters).
  --get-ringtone        Show the stored ringtone
  --set-ringtone SET_RINGTONE
                        Set the Notification Ringtone (up to 230 characters).
  --ch-vlongslow        Change to the very long-range and slow modem preset
  --ch-longslow         Change to the long-range and slow modem preset
  --ch-longfast         Change to the long-range and fast modem preset
  --ch-medslow          Change to the med-range and slow modem preset
  --ch-medfast          Change to the med-range and fast modem preset
  --ch-shortslow        Change to the short-range and slow modem preset
  --ch-shortfast        Change to the short-range and fast modem preset
  --set-owner SET_OWNER
                        Set device owner name
  --set-owner-short SET_OWNER_SHORT
                        Set device owner short name
  --set-ham SET_HAM     Set licensed Ham ID and turn off encryption
  --seturl SETURL       Set a channel URL

Position Configuration:
  Arguments that modify fixed position and other position-related configuration.

  --setalt SETALT       Set device altitude in meters (allows use without GPS), and enable fixed position. When providing positions with `--setlat`, `--setlon`,
                        and `--setalt`, missing values will be set to 0.
  --setlat SETLAT       Set device latitude (allows use without GPS), and enable fixed position. Accepts a decimal value or an integer premultiplied by 1e7. When
                        providing positions with `--setlat`, `--setlon`, and `--setalt`, missing values will be set to 0.
  --setlon SETLON       Set device longitude (allows use without GPS), and enable fixed position. Accepts a decimal value or an integer premultiplied by 1e7.
                        When providing positions with `--setlat`, `--setlon`, and `--setalt`, missing values will be set to 0.
  --remove-position     Clear any existing fixed position and disable fixed position.
  --pos-fields [POS_FIELDS ...]
                        Specify fields to send when sending a position. Use no argument for a list of valid values. Can pass multiple values as a space separated
                        list like this: '--pos-fields ALTITUDE HEADING SPEED'

Channel Configuration:
  Arguments that concern configuration of channels

  --ch-add CH_ADD       Add a secondary channel, you must specify a channel name
  --ch-del              Delete the ch-index channel
  --ch-set CH_SET CH_SET
                        Set a channel parameter. To see channel settings available:'--ch-set all all --ch-index 0'. Can set the 'psk' using this command. To
                        disable encryption on primary channel:'--ch-set psk none --ch-index 0'. To set encryption with a new random key on second channel:'--ch-
                        set psk random --ch-index 1'. To set encryption back to the default:'--ch-set psk default --ch-index 0'. To set encryption with your own
                        key: '--ch-set psk 0x1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b --ch-index 0'.
  --channel-fetch-attempts CHANNEL_FETCH_ATTEMPTS
                        Attempt to retrieve channel settings for --ch-set this many times before giving up. Default 3.
  --qr                  Display a QR code for the node's primary channel (or all channels with --qr-all). Also shows the shareable channel URL.
  --qr-all              Display a QR code and URL for all of the node's channels.
  --ch-enable           Enable the specified channel. Use --ch-add instead whenever possible.
  --ch-disable          Disable the specified channel Use --ch-del instead whenever possible.

Local Actions:
  Arguments that take actions or request information from the local node only.

  --info                Read and display the radio config information
  --nodes               Print Node List in a pretty formatted table

Remote Actions:
  Arguments that take actions or request information from either the local node or remote nodes via the mesh.

  --sendtext SENDTEXT   Send a text message. Can specify a destination '--dest' and/or channel index '--ch-index'.
  --traceroute TRACEROUTE
                        Traceroute from connected node to a destination. You need pass the destination ID as argument, like this: '--traceroute !ba4bf9d0' Only
                        nodes that have the encryption key can be traced.
  --request-telemetry   Request telemetry from a node. You need to pass the destination ID as argument with '--dest'. For repeaters, the nodeNum is required.
  --request-position    Request the position from a node. You need to pass the destination ID as an argument with '--dest'. For repeaters, the nodeNum is
                        required.
  --reply               Reply to received messages

Remote Admin Actions:
  Arguments that interact with local node or remote nodes via the mesh, requiring admin access.

  --reboot              Tell the destination node to reboot
  --reboot-ota          Tell the destination node to reboot into factory firmware (ESP32)
  --enter-dfu           Tell the destination node to enter DFU mode (NRF52)
  --shutdown            Tell the destination node to shutdown
  --device-metadata     Get the device metadata from the node
  --factory-reset, --factory-reset-config
                        Tell the destination node to install the default config, preserving BLE bonds & PKI keys
  --factory-reset-device
                        Tell the destination node to install the default config and clear BLE bonds & PKI keys
  --remove-node !xxxxxxxx
                        Tell the destination node to remove a specific node from its DB, by node number or ID
  --reset-nodedb        Tell the destination node to clear its list of nodes
  --set-time [TIMESTAMP]
                        Set the time to the provided unix epoch timestamp, or the system's current time if omitted or 0.

Miscellaneous arguments:
  --seriallog [LOG_DESTINATION]
                        Log device serial output to either 'none' or a filename to append to. Defaults to 'stdout' if no filename specified.
  --ack                 Use in combination with compatible actions (e.g. --sendtext) to wait for an acknowledgment.
  --timeout SECONDS     How long to wait for replies. Default 300s.
  --no-nodes            Request that the node not send node info to the client. Will break things that depend on the nodedb, but will speed up startup. Requires
                        2.3.11+ firmware.
  --debug               Show API library debug log messages
  --test                Run stress test against all connected Meshtastic devices
  --wait-to-disconnect [SECONDS]
                        How many seconds to wait before disconnecting from the device.
  --noproto             Don't start the API, just function as a dumb serial terminal.
  --listen              Just stay open and listen to the protobuf stream. Enables debug logging.
  --no-time             Deprecated. Retained for backwards compatibility in scripts, but is a no-op.

Power Testing:
  Options for power testing/logging.

  --power-riden POWER_RIDEN
                        Talk to a Riden power-supply. You must specify the device path, i.e. /dev/ttyUSBxxx
  --power-ppk2-meter    Talk to a Nordic Power Profiler Kit 2 (in meter mode)
  --power-ppk2-supply   Talk to a Nordic Power Profiler Kit 2 (in supply mode)
  --power-sim           Use a simulated power meter (for development)
  --power-voltage POWER_VOLTAGE
                        Set the specified voltage on the power-supply. Be VERY careful, you can burn things up.
  --power-stress        Perform power monitor stress testing, to capture a power consumption profile for the device (also requires --power-mon)
  --power-wait          Prompt the user to wait for device reset before looking for device serial ports (some boards kill power to USB serial port)
  --slog [SLOG]         Store structured-logs (slogs) for this run, optionally you can specifiy a destination directory

Remote Hardware:
  Arguments related to the Remote Hardware module

  --gpio-wrb GPIO_WRB GPIO_WRB
                        Set a particular GPIO # to 1 or 0
  --gpio-rd GPIO_RD     Read from a GPIO mask (ex: '0x10')
  --gpio-watch GPIO_WATCH
                        Start watching a GPIO mask for changes (ex: '0x10')

Tunnel:
  Arguments related to establishing a tunnel device over the mesh.

  --tunnel              Create a TUN tunnel device for forwarding IP packets over the mesh
  --subnet TUNNEL_NET   Sets the local-end subnet address for the TUN IP bridge. (ex: 10.115' which is the default)

If no connection arguments are specified, we search for a compatible serial device, and if none is found, then attempt a TCP connection to localhost.```