### PR TITLE
autoprint other types of telemetry when returned from --request-telemetry 

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -661,22 +661,32 @@ class MeshInterface:  # pylint: disable=R0902
             self._acknowledgment.receivedTelemetry = True
             telemetry = telemetry_pb2.Telemetry()
             telemetry.ParseFromString(p["decoded"]["payload"])
-
             print("Telemetry received:")
-            if telemetry.device_metrics.battery_level is not None:
-                print(f"Battery level: {telemetry.device_metrics.battery_level:.2f}%")
-            if telemetry.device_metrics.voltage is not None:
-                print(f"Voltage: {telemetry.device_metrics.voltage:.2f} V")
-            if telemetry.device_metrics.channel_utilization is not None:
-                print(
-                    f"Total channel utilization: {telemetry.device_metrics.channel_utilization:.2f}%"
-                )
-            if telemetry.device_metrics.air_util_tx is not None:
-                print(
-                    f"Transmit air utilization: {telemetry.device_metrics.air_util_tx:.2f}%"
-                )
-            if telemetry.device_metrics.uptime_seconds is not None:
-                print(f"Uptime: {telemetry.device_metrics.uptime_seconds} s")
+            # Check if the telemetry message has the device_metrics field
+            # This is the original code that was the default for --request-telemetry and is kept for compatibility
+            if telemetry.HasField("device_metrics"):
+                if telemetry.device_metrics.battery_level is not None:
+                    print(f"Battery level: {telemetry.device_metrics.battery_level:.2f}%")
+                if telemetry.device_metrics.voltage is not None:
+                    print(f"Voltage: {telemetry.device_metrics.voltage:.2f} V")
+                if telemetry.device_metrics.channel_utilization is not None:
+                    print(
+                        f"Total channel utilization: {telemetry.device_metrics.channel_utilization:.2f}%"
+                    )
+                if telemetry.device_metrics.air_util_tx is not None:
+                    print(
+                        f"Transmit air utilization: {telemetry.device_metrics.air_util_tx:.2f}%"
+                    )
+                if telemetry.device_metrics.uptime_seconds is not None:
+                    print(f"Uptime: {telemetry.device_metrics.uptime_seconds} s")
+            else:
+                # this is the new code if --request-telemetry <type> is used.
+                telemetry_dict = google.protobuf.json_format.MessageToDict(telemetry)
+                for key, value in telemetry_dict.items():
+                    if key != "time": # protobuf includes a time field that we don't print for device_metrics.
+                        print(f"{key}:")
+                        for sub_key, sub_value in value.items():
+                            print(f"  {sub_key}: {sub_value}")
 
         elif p["decoded"]["portnum"] == "ROUTING_APP":
             if p["decoded"]["routing"]["errorReason"] == "NO_RESPONSE":


### PR DESCRIPTION
Fixes #690.

I didn't want to break the existing output from `device_metrics` in case people are depending on that specific format, but this is begging for a `--json` switch in the future.

This approach (iterating and printing keys) should make the output more future proof if/when the protobufs change over time.

Example when requesting !device_metrics:
```
❯ poetry run meshtastic --request-telemetry power --dest '!dc3b65fb'
Connected to radio
Sending power_metrics telemetry request to !dc3b65fb on channelIndex:0 (this could take a while)
Telemetry received:
powerMetrics:
  ch1Voltage: 16.08
  ch1Current: 4.0
  ch2Voltage: 2.68
  ch2Current: 37.6
  ch3Voltage: 0.0
  ch3Current: 0.0

> poetry run meshtastic --request-telemetry environment --dest '!dc3b65fb'
Connected to radio
Sending environment_metrics telemetry request to !dc3b65fb on channelIndex:0 (this could take a while)
Telemetry received:
environmentMetrics:
  temperature: 17.26
  relativeHumidity: 66.96
  voltage: 16.08
  current: 4.4

```

Example when not specifying a type, or when specifically requesting `device`:
```
at 16:59:16 ❯ poetry run meshtastic --request-telemetry device --dest '!dc3b65fb'
Connected to radio
Sending device_metrics telemetry request to !dc3b65fb on channelIndex:0 (this could take a while)
Telemetry received:
Battery level: 15.00%
Voltage: 3.36 V
Total channel utilization: 10.72%
Transmit air utilization: 2.20%
Uptime: 792641 s

at 17:02:25 ❯ poetry run meshtastic --request-telemetry --dest '!dc3b65fb'
Connected to radio
Sending device_metrics telemetry request to !dc3b65fb on channelIndex:0 (this could take a while)
Telemetry received:
Battery level: 15.00%
Voltage: 3.37 V
Total channel utilization: 20.17%
Transmit air utilization: 2.22%
Uptime: 792641 s
```