### PR TITLE
Add missing camel to snake conversion

### DIFF
--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -121,7 +121,7 @@ class Node:
                 )
                 return
             if config_values is not None:
-                raw_config = getattr(getattr(adminMessage['raw'], oneof), field)
+                raw_config = getattr(getattr(adminMessage['raw'], oneof), camel_to_snake(field))
                 config_values.CopyFrom(raw_config)
                 print(f"{str(camel_to_snake(field))}:\n{str(config_values)}")
 


### PR DESCRIPTION
Before this patch:
```
$ meshtastic --dest '!nodeid' --get external_notification
Connected to radio
Requesting current config from remote node (this can take a while).

ERROR file:stream_interface.py __reader line:191 Error while handling message from radio externalNotification
Traceback (most recent call last):
  File "/home/eswanson/.local/lib/python3.12/site-packages/meshtastic/stream_interface.py", line 189, in __reader
    self._handleFromRadio(self._rxBuf[HEADER_LEN:])
  File "/home/eswanson/.local/lib/python3.12/site-packages/meshtastic/mesh_interface.py", line 1097, in _handleFromRadio
    self._handlePacketFromRadio(fromRadio.packet)
  File "/home/eswanson/.local/lib/python3.12/site-packages/meshtastic/mesh_interface.py", line 1379, in _handlePacketFromRadio
    handler.callback(asDict)
  File "/home/eswanson/.local/lib/python3.12/site-packages/meshtastic/node.py", line 124, in onResponseRequestSettings
    raw_config = getattr(getattr(adminMessage['raw'], oneof), field)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: externalNotification. Did you mean: 'ExternalNotificationConfig'?
Completed getting preferences
```

There sure are a lot of :camel: and :snake: in this project.