### PR TITLE
Add new channels from an add URL with the new --ch-add-url option

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -674,9 +674,9 @@ def onConnected(interface):
             closeNow = True
             export_config(interface)
 
-        if args.seturl:
+        if args.ch_set_url:
             closeNow = True
-            interface.getNode(args.dest, **getNode_kwargs).setURL(args.seturl)
+            interface.getNode(args.dest, **getNode_kwargs).setURL(args.ch_set_url, addOnly=False)
 
         # handle changing channels
 
@@ -1447,7 +1447,20 @@ def addConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "--set-ham", help="Set licensed Ham ID and turn off encryption", action="store"
     )
 
-    group.add_argument("--seturl", help="Set all channels with a URL", action="store")
+    group.add_argument(
+        "--ch-set-url", "--seturl",
+        help="Set all channels and set LoRa config from a supplied URL",
+        metavar="URL",
+        action="store"
+    )
+
+    group.add_argument(
+        "--ch-add-url",
+        help="Add secondary channels and set LoRa config from a supplied URL",
+        metavar="URL",
+        default=None,
+    )
+
 
     return parser
 
@@ -1462,13 +1475,6 @@ def addChannelConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
     group.add_argument(
         "--ch-add",
         help="Add a secondary channel, you must specify a channel name",
-        default=None,
-    )
-
-    group.add_argument(
-        "--ch-add-url",
-        help="Add secondary channels from a supplied URL",
-        metavar="URL",
         default=None,
     )
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -680,6 +680,10 @@ def onConnected(interface):
 
         # handle changing channels
 
+        if args.ch_add_url:
+            closeNow = True
+            interface.getNode(args.dest, **getNode_kwargs).setURL(args.ch_add_url, addOnly=True)
+
         if args.ch_add:
             channelIndex = mt_config.channel_index
             if channelIndex is not None:
@@ -1443,7 +1447,7 @@ def addConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "--set-ham", help="Set licensed Ham ID and turn off encryption", action="store"
     )
 
-    group.add_argument("--seturl", help="Set a channel URL", action="store")
+    group.add_argument("--seturl", help="Set all channels with a URL", action="store")
 
     return parser
 
@@ -1458,6 +1462,13 @@ def addChannelConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
     group.add_argument(
         "--ch-add",
         help="Add a secondary channel, you must specify a channel name",
+        default=None,
+    )
+
+    group.add_argument(
+        "--ch-add-url",
+        help="Add secondary channels from a supplied URL",
+        metavar="URL",
         default=None,
     )
 

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -270,7 +270,7 @@ def test_setURL_empty_url(capsys):
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1
     out, err = capsys.readouterr()
-    assert re.search(r"Warning: There were no settings.", out, re.MULTILINE)
+    assert re.search(r"Warning: config or channels not loaded", out, re.MULTILINE)
     assert err == ""
 
 
@@ -304,7 +304,7 @@ def test_setURL_valid_URL_but_no_settings(capsys):
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1
     out, err = capsys.readouterr()
-    assert re.search(r"Warning: There were no settings", out, re.MULTILINE)
+    assert re.search(r"Warning: config or channels not loaded", out, re.MULTILINE)
     assert err == ""
 
 


### PR DESCRIPTION
I added CLI option `--ch-add-url` with which one can provide an "add" URL to add new channel(s) to a node.

It won't make any changes to the primary channel or any existing secondary channels with the same name as a channel in the URL.

If the provided URL is not valid, it errors out with a relevant message.