### PR TITLE
Add text message port cli option

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -442,7 +442,8 @@ def onConnected(interface):
             channelIndex = mt_config.channel_index or 0
             if checkChannel(interface, channelIndex):
                 print(
-                    f"Sending text message {args.sendtext} to {args.dest} on channelIndex:{channelIndex} {"using PRIVATE_APP port" if args.private else ""}"
+                    f"Sending text message {args.sendtext} to {args.dest} on channelIndex:{channelIndex}"
+                    f" {'using PRIVATE_APP port' if args.private else ''}"
                 )
                 interface.sendText(
                     args.sendtext,

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -442,7 +442,7 @@ def onConnected(interface):
             channelIndex = mt_config.channel_index or 0
             if checkChannel(interface, channelIndex):
                 print(
-                    f"Sending text message {args.sendtext} to {args.dest}:{args.textport} on channelIndex:{channelIndex}"
+                    f"Sending text message {args.sendtext} to {args.dest} on channelIndex:{channelIndex} {"using PRIVATE_APP port" if args.private else ""}"
                 )
                 interface.sendText(
                     args.sendtext,
@@ -450,7 +450,7 @@ def onConnected(interface):
                     wantAck=True,
                     channelIndex=channelIndex,
                     onResponse=interface.getNode(args.dest, False, **getNode_kwargs).onAckNak,
-                    portNum=args.textport
+                    portNum=portnums_pb2.PortNum.PRIVATE_APP if args.private else portnums_pb2.PortNum.TEXT_MESSAGE_APP
                 )
             else:
                 meshtastic.util.our_exit(
@@ -1593,16 +1593,14 @@ def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
 
     group.add_argument(
         "--sendtext",
-        help="Send a text message. Can specify a destination '--dest', port '--textport', and/or channel index '--ch-index'.",
+        help="Send a text message. Can specify a destination '--dest', use of PRIVATE_APP port '--private', and/or channel index '--ch-index'.",
         metavar="TEXT",
     )
 
-    group.add_argument( 
-        "--textport",
-        help="Optional argument for sending text messages to the non default port. Use in combination with --sendtext.",
-        type=int,
-        default=portnums_pb2.PortNum.TEXT_MESSAGE_APP,
-        metavar="PORT"
+    group.add_argument(
+        "--private",
+        help="Optional argument for sending text messages to the PRIVATE_APP port. Use in combination with --sendtext.",
+        action="store_true"
     )
 
     group.add_argument(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -442,7 +442,7 @@ def onConnected(interface):
             channelIndex = mt_config.channel_index or 0
             if checkChannel(interface, channelIndex):
                 print(
-                    f"Sending text message {args.sendtext} to {args.dest} on channelIndex:{channelIndex}"
+                    f"Sending text message {args.sendtext} to {args.dest}:{args.textport} on channelIndex:{channelIndex}"
                 )
                 interface.sendText(
                     args.sendtext,
@@ -450,6 +450,7 @@ def onConnected(interface):
                     wantAck=True,
                     channelIndex=channelIndex,
                     onResponse=interface.getNode(args.dest, False, **getNode_kwargs).onAckNak,
+                    portNum=args.textport
                 )
             else:
                 meshtastic.util.our_exit(
@@ -1592,8 +1593,16 @@ def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
 
     group.add_argument(
         "--sendtext",
-        help="Send a text message. Can specify a destination '--dest' and/or channel index '--ch-index'.",
+        help="Send a text message. Can specify a destination '--dest', port '--textport', and/or channel index '--ch-index'.",
         metavar="TEXT",
+    )
+
+    group.add_argument( 
+        "--textport",
+        help="Optional argument for sending text messages to the non default port. Use in combination with --sendtext.",
+        type=int,
+        default=portnums_pb2.PortNum.TEXT_MESSAGE_APP,
+        metavar="PORT"
     )
 
     group.add_argument(

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -354,7 +354,7 @@ class MeshInterface:  # pylint: disable=R0902
         wantResponse: bool = False,
         onResponse: Optional[Callable[[dict], Any]] = None,
         channelIndex: int = 0,
-        portNum: int = portnums_pb2.PortNum.TEXT_MESSAGE_APP
+        portNum: portnums_pb2.PortNum.ValueType = portnums_pb2.PortNum.TEXT_MESSAGE_APP
     ):
         """Send a utf8 string to some other node, if the node has a display it
            will also be shown on the device.

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -354,6 +354,7 @@ class MeshInterface:  # pylint: disable=R0902
         wantResponse: bool = False,
         onResponse: Optional[Callable[[dict], Any]] = None,
         channelIndex: int = 0,
+        portNum: int = portnums_pb2.PortNum.TEXT_MESSAGE_APP
     ):
         """Send a utf8 string to some other node, if the node has a display it
            will also be shown on the device.
@@ -364,12 +365,12 @@ class MeshInterface:  # pylint: disable=R0902
         Keyword Arguments:
             destinationId {nodeId or nodeNum} -- where to send this
                                                  message (default: {BROADCAST_ADDR})
-            portNum -- the application portnum (similar to IP port numbers)
-                       of the destination, see portnums.proto for a list
             wantAck -- True if you want the message sent in a reliable manner
                        (with retries and ack/nak provided for delivery)
             wantResponse -- True if you want the service on the other side to
                             send an application layer response
+            portNum -- the application portnum (similar to IP port numbers)
+                       of the destination, see portnums.proto for a list
 
         Returns the sent packet. The id field will be populated in this packet
         and can be used to track future message acks/naks.
@@ -378,7 +379,7 @@ class MeshInterface:  # pylint: disable=R0902
         return self.sendData(
             text.encode("utf-8"),
             destinationId,
-            portNum=portnums_pb2.PortNum.TEXT_MESSAGE_APP,
+            portNum=portNum,
             wantAck=wantAck,
             wantResponse=wantResponse,
             onResponse=onResponse,

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -593,10 +593,10 @@ def test_main_sendtext(capsys):
     iface = MagicMock(autospec=SerialInterface)
 
     def mock_sendText(
-        text, dest, wantAck=False, wantResponse=False, onResponse=None, channelIndex=0
+        text, dest, wantAck=False, wantResponse=False, onResponse=None, channelIndex=0, portNum=0
     ):
         print("inside mocked sendText")
-        print(f"{text} {dest} {wantAck} {wantResponse} {channelIndex}")
+        print(f"{text} {dest} {wantAck} {wantResponse} {channelIndex} {portNum}")
 
     iface.sendText.side_effect = mock_sendText
 
@@ -620,10 +620,10 @@ def test_main_sendtext_with_channel(capsys):
     iface = MagicMock(autospec=SerialInterface)
 
     def mock_sendText(
-        text, dest, wantAck=False, wantResponse=False, onResponse=None, channelIndex=0
+        text, dest, wantAck=False, wantResponse=False, onResponse=None, channelIndex=0, portNum=0
     ):
         print("inside mocked sendText")
-        print(f"{text} {dest} {wantAck} {wantResponse} {channelIndex}")
+        print(f"{text} {dest} {wantAck} {wantResponse} {channelIndex} {portNum}")
 
     iface.sendText.side_effect = mock_sendText
 


### PR DESCRIPTION
## What did you change?
I added a command line option '--textport' that lets you send text to an arbitrary port number.

## Why did you change it?
When developing a new meshtastic firmware module, there isn't a super easy way to send arbitrary text packets to a module. Previously, module developers that just want to receive text data for testing purposes would likely make their module receive normal text messages (port 1) during development which is a bit of a hack-y solution. Or, developers would have to leave the comfort of their command line and write a script to send the messages on the custom port.

## Screenshot
 
![screenshot-edited](https://github.com/user-attachments/assets/5638c623-30ab-48b1-805b-0fb106435012)

