### PR TITLE
Make several dependencies optional (dotmap, print_color, and pyqrcode)

### DIFF
--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -80,7 +80,6 @@ from typing import *
 
 import google.protobuf.json_format
 import serial # type: ignore[import-untyped]
-from dotmap import DotMap # type: ignore[import-untyped]
 from google.protobuf.json_format import MessageToJson
 from pubsub import pub # type: ignore[import-untyped]
 from tabulate import tabulate

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -18,7 +18,12 @@ import yaml
 from google.protobuf.json_format import MessageToDict
 from pubsub import pub  # type: ignore[import-untyped]
 
-import meshtastic.test
+try:
+    import meshtastic.test
+    have_test = True
+except ImportError as e:
+    have_test = False
+
 import meshtastic.util
 from meshtastic import BROADCAST_ADDR, mt_config, remote_hardware
 from meshtastic.ble_interface import BLEInterface
@@ -1143,11 +1148,14 @@ def common():
             parser.print_help(sys.stderr)
             meshtastic.util.our_exit("", 1)
         elif args.test:
-            result = meshtastic.test.testAll()
-            if not result:
-                meshtastic.util.our_exit("Warning: Test was not successful.")
+            if not have_test:
+                meshtastic.util.our_exit("Test module could not be important. Ensure you have the 'dotmap' module installed.")
             else:
-                meshtastic.util.our_exit("Test was a success.", 0)
+                result = meshtastic.test.testAll()
+                if not result:
+                    meshtastic.util.our_exit("Warning: Test was not successful.")
+                else:
+                    meshtastic.util.our_exit("Test was a success.", 0)
         else:
             if args.seriallog == "stdout":
                 logfile = sys.stdout

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -13,7 +13,11 @@ import sys
 import time
 from typing import List, Optional
 
-import pyqrcode  # type: ignore[import-untyped]
+try:
+    import pyqrcode  # type: ignore[import-untyped]
+except ImportError as e:
+    pyqrcode = None
+
 import yaml
 from google.protobuf.json_format import MessageToDict
 from pubsub import pub  # type: ignore[import-untyped]
@@ -896,8 +900,11 @@ def onConnected(interface):
             else:
                 urldesc = "Primary channel URL"
             print(f"{urldesc}: {url}")
-            qr = pyqrcode.create(url)
-            print(qr.terminal())
+            if pyqrcode is not None:
+                qr = pyqrcode.create(url)
+                print(qr.terminal())
+            else:
+                print("Install pyqrcode to view a QR code printed to terminal.")
 
         log_set: Optional = None  # type: ignore[annotation-unchecked]
         # we need to keep a reference to the logset so it doesn't get GCed early

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -15,7 +15,11 @@ from decimal import Decimal
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import google.protobuf.json_format
-import print_color  # type: ignore[import-untyped]
+try:
+    import print_color  # type: ignore[import-untyped]
+except ImportError as e:
+    print_color = None
+
 from pubsub import pub  # type: ignore[import-untyped]
 from tabulate import tabulate
 
@@ -153,7 +157,7 @@ class MeshInterface:  # pylint: disable=R0902
     @staticmethod
     def _printLogLine(line, interface):
         """Print a line of log output."""
-        if interface.debugOut == sys.stdout:
+        if print_color is not None and interface.debugOut == sys.stdout:
             # this isn't quite correct (could cause false positives), but currently our formatting differs between different log representations
             if "DEBUG" in line:
                 print_color.print(line, color="cyan", end=None)

--- a/poetry.lock
+++ b/poetry.lock
@@ -944,7 +944,7 @@ profile = ["gprof2dot (>=2022.7.29)"]
 name = "dotmap"
 version = "1.3.30"
 description = "ordered, dynamically-expandable dot-access dictionary"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "dotmap-1.3.30-py3-none-any.whl", hash = "sha256:bd9fa15286ea2ad899a4d1dc2445ed85a1ae884a42effb87c89a6ecce71243c6"},
@@ -2705,7 +2705,7 @@ pyserial = "*"
 name = "print-color"
 version = "0.4.6"
 description = "A simple package to print in color to the terminal"
-optional = false
+optional = true
 python-versions = ">=3.7,<4.0"
 files = [
     {file = "print_color-0.4.6-py3-none-any.whl", hash = "sha256:494bd1cdb84daf481f0e63bd22b3c32f7d52827d8f5d9138a96bb01ca8ba9299"},
@@ -4337,4 +4337,4 @@ tunnel = ["pytap2"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<3.14"
-content-hash = "cc2529666461aa69024abd86d14b2ac220a965a82dded2309b9e0980f5e1b328"
+content-hash = "21b6a8041c1bbd7b970a7af37621690715db771488950c72087e60d922a2ff95"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3094,7 +3094,7 @@ files = [
 name = "pyqrcode"
 version = "1.2.1"
 description = "A QR code generator written purely in Python with SVG, EPS, PNG and terminal output."
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "PyQRCode-1.2.1.tar.gz", hash = "sha256:fdbf7634733e56b72e27f9bce46e4550b75a3a2c420414035cae9d9d26b234d5"},
@@ -4337,4 +4337,4 @@ tunnel = ["pytap2"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<3.14"
-content-hash = "21b6a8041c1bbd7b970a7af37621690715db771488950c72087e60d922a2ff95"
+content-hash = "d3eefb76e586ad6625c1fce7b73244ba1d663aa5b4916c47bd1daa5f2bdcc913"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4332,9 +4332,10 @@ type = ["pytest-mypy"]
 
 [extras]
 analysis = ["dash", "dash-bootstrap-components", "pandas", "pandas-stubs"]
+cli = ["dotmap", "print-color", "pyqrcode"]
 tunnel = ["pytap2"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<3.14"
-content-hash = "d3eefb76e586ad6625c1fce7b73244ba1d663aa5b4916c47bd1daa5f2bdcc913"
+content-hash = "fa490a41df9742f691c43a4915f7751b6adbded7605c3f0936f74681c1da5244"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ ipywidgets = "^8.1.3"
 jupyterlab-widgets = "^3.0.11"
 
 [tool.poetry.extras]
+cli = ["pyqrcode", "print-color", "dotmap"]
 tunnel = ["pytap2"]
 analysis = ["dash", "dash-bootstrap-components", "pandas", "pandas-stubs"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 python = "^3.9,<3.14"                                               # 3.9 is needed for pandas, bleak requires <3.14
 pyserial = "^3.5"
 protobuf = ">=4.21.12"
-dotmap = "^1.3.30"
 pyqrcode = "^1.2.1"
 tabulate = "^0.9.0"
 requests = "^2.31.0"
@@ -18,7 +17,8 @@ pyyaml = "^6.0.1"
 pypubsub = "^4.0.3"
 bleak = "^0.22.3"
 packaging = "^24.0"
-print-color = "^0.4.6"
+dotmap = { version = "^1.3.30", optional = true }
+print-color = { version = "^0.4.6", optional = true }
 dash = { version = "^2.17.1", optional = true }
 pytap2 = { version = "^2.3.0", optional = true }
 dash-bootstrap-components = { version = "^1.6.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ readme = "README.md"
 python = "^3.9,<3.14"                                               # 3.9 is needed for pandas, bleak requires <3.14
 pyserial = "^3.5"
 protobuf = ">=4.21.12"
-pyqrcode = "^1.2.1"
 tabulate = "^0.9.0"
 requests = "^2.31.0"
 pyyaml = "^6.0.1"
 pypubsub = "^4.0.3"
 bleak = "^0.22.3"
 packaging = "^24.0"
+pyqrcode = { version = "^1.2.1", optional = true }
 dotmap = { version = "^1.3.30", optional = true }
 print-color = { version = "^0.4.6", optional = true }
 dash = { version = "^2.17.1", optional = true }


### PR DESCRIPTION
This should assist with packaging, especially in more limited environments such as openwrt and buildroot.

* dotmap is only used by the meshtastic.test namespace, so now it's imported in a try-catch block
* logs will only be printed in color if print_color is installed
* the QR code will only be printed if pyqrcode is installed, but users will be pointed to install it if they want (the QR code options still print the URL itself out)