### PR TITLE
Fix windows-11 detection for non-float platform.release() values

### DIFF
--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -442,6 +442,13 @@ def test_is_windows11_false_win8_1(patched_platform, patched_release):
     patched_platform.assert_called()
     patched_release.assert_called()
 
+@patch("platform.release", return_value="2022Server")
+@patch("platform.system", return_value="Windows")
+def test_is_windows11_false_winserver(patched_platform, patched_release):
+    """Test is_windows11()"""
+    assert is_windows11() is False
+    patched_platform.assert_called()
+    patched_release.assert_called()
 
 @pytest.mark.unit
 @patch("platform.system", return_value="Linux")

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -521,15 +521,15 @@ def is_windows11() -> bool:
     """Detect if Windows 11"""
     is_win11: bool = False
     if platform.system() == "Windows":
-        if float(platform.release()) >= 10.0:
-            patch = platform.version().split(".")[2]
-            # in case they add some number suffix later, just get first 5 chars of patch
-            patch = patch[:5]
-            try:
+        try:
+            if float(platform.release()) >= 10.0:
+                patch = platform.version().split(".")[2]
+                # in case they add some number suffix later, just get first 5 chars of patch
+                patch = patch[:5]
                 if int(patch) >= 22000:
                     is_win11 = True
-            except Exception as e:
-                print(f"problem detecting win11 e:{e}")
+        except Exception as e:
+            print(f"problem detecting win11 e:{e}")
     return is_win11
 
 


### PR DESCRIPTION
(fixes #639)

@tuesdays if you get a chance, would you be able to test this? I'm defaulting to this being set as "not windows 11".