### PR TITLE
Add very simple shell completion using argcomplete

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -6,6 +6,11 @@
 # pylint: disable=too-many-lines
 
 import argparse
+try:
+    import argcomplete
+except ImportError as e:
+    argcomplete = None
+
 import logging
 import os
 import platform
@@ -1961,6 +1966,8 @@ def initParser():
 
     parser.set_defaults(deprecated=None)
 
+    if argcomplete is not None:
+        argcomplete.autocomplete(parser)
     args = parser.parse_args()
     mt_config.args = args
     mt_config.parser = parser

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -5,18 +5,21 @@
 # later we can have a separate changelist to refactor main.py into smaller files
 # pylint: disable=too-many-lines
 
+from typing import List, Optional, Union
+from types import ModuleType
+
 import argparse
+argcomplete: Union[None, ModuleType] = None
 try:
     import argcomplete
 except ImportError as e:
-    argcomplete = None
+    pass # already set to None by default above
 
 import logging
 import os
 import platform
 import sys
 import time
-from typing import List, Optional
 
 try:
     import pyqrcode  # type: ignore[import-untyped]

--- a/poetry.lock
+++ b/poetry.lock
@@ -45,6 +45,20 @@ files = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.5.2"
+description = "Bash tab completion for argparse"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "argcomplete-3.5.2-py3-none-any.whl", hash = "sha256:036d020d79048a5d525bc63880d7a4b8d1668566b8a76daf1144c0bbe0f63472"},
+    {file = "argcomplete-3.5.2.tar.gz", hash = "sha256:23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"},
+]
+
+[package.extras]
+test = ["coverage", "mypy", "pexpect", "ruff", "wheel"]
+
+[[package]]
 name = "argon2-cffi"
 version = "23.1.0"
 description = "Argon2 for Python"
@@ -4332,10 +4346,10 @@ type = ["pytest-mypy"]
 
 [extras]
 analysis = ["dash", "dash-bootstrap-components", "pandas", "pandas-stubs"]
-cli = ["dotmap", "print-color", "pyqrcode"]
+cli = ["argcomplete", "dotmap", "print-color", "pyqrcode"]
 tunnel = ["pytap2"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<3.14"
-content-hash = "fa490a41df9742f691c43a4915f7751b6adbded7605c3f0936f74681c1da5244"
+content-hash = "4ab787ea28390a4e19c2dfbfdee920174146b144a63fa1e138e25b7120941490"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ pyyaml = "^6.0.1"
 pypubsub = "^4.0.3"
 bleak = "^0.22.3"
 packaging = "^24.0"
+argcomplete = { version = "^3.5.2", optional = true }
 pyqrcode = { version = "^1.2.1", optional = true }
 dotmap = { version = "^1.3.30", optional = true }
 print-color = { version = "^0.4.6", optional = true }
@@ -64,7 +65,7 @@ ipywidgets = "^8.1.3"
 jupyterlab-widgets = "^3.0.11"
 
 [tool.poetry.extras]
-cli = ["pyqrcode", "print-color", "dotmap"]
+cli = ["pyqrcode", "print-color", "dotmap", "argcomplete"]
 tunnel = ["pytap2"]
 analysis = ["dash", "dash-bootstrap-components", "pandas", "pandas-stubs"]
 


### PR DESCRIPTION
Fixes #640 in a rudimentary sort of fashion.

This could probably be improved upon by way of the process shown in [the argcomplete docs](https://github.com/kislyuk/argcomplete?tab=readme-ov-file#specifying-completers) -- but, it may also be the kind of thing that would depend on local persistence to be very efficient. This does at least add basic completion, which can be enabled with: `eval "$(register-python-argcomplete meshtastic)"` (which can be put into a bashrc or similar). I'm unclear if argcomplete's support for global completion will work at present.