### PR TITLE
464: allow for 0x node prefix values

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1649,7 +1649,6 @@ def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
         "You need pass the destination ID as argument, like "
         "this: '--traceroute !ba4bf9d0' "
         "Only nodes with a shared channel can be traced.",
-        nargs=1,
         metavar=("!XXXXXXXX", "0xXXXXXXXX"),
     )
 
@@ -1730,31 +1729,26 @@ def addRemoteAdminArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     group.add_argument(
         "--remove-node",
         help="Tell the destination node to remove a specific node from its DB, by node number or ID",
-        nargs=1,
         metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(
         "--set-favorite-node",
         help="Tell the destination node to set the specified node to be favorited on the NodeDB on the devicein its DB, by number or ID",
-        nargs=1,
         metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(
         "--remove-favorite-node",
         help="Tell the destination node to set the specified node to be un-favorited on the NodeDB on the device, by number or ID",
-        nargs=1,
         metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(
         "--set-ignored-node",
         help="Tell the destination node to set the specified node to be ignored on the NodeDB on the devicein its DB, by number or ID",
-        nargs=1,
-        metavar=("!XXXXXXXX", "0xXXXXXXXX")
+        metavar="!XXXXXXXX"
     )
     group.add_argument(
         "--remove-ignored-node",
         help="Tell the destination node to set the specified node to be un-ignored on the NodeDB on the device, by number or ID",
-        nargs=1,
         metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1344,7 +1344,7 @@ def addSelectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         "--dest",
         help="The destination node id for any sent commands, if not set '^all' or '^local' is assumed as appropriate",
         default=None,
-        metavar=["!XXXXXXXX", "0xXXXXXXXX"],
+        metavar=("!XXXXXXXX", "0xXXXXXXXX"),
     )
 
     group.add_argument(
@@ -1648,7 +1648,7 @@ def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
         "You need pass the destination ID as argument, like "
         "this: '--traceroute !ba4bf9d0' "
         "Only nodes with a shared channel can be traced.",
-        metavar=["!XXXXXXXX", "0xXXXXXXXX"],
+        metavar=("!XXXXXXXX", "0xXXXXXXXX"),
     )
 
     group.add_argument(
@@ -1728,27 +1728,27 @@ def addRemoteAdminArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     group.add_argument(
         "--remove-node",
         help="Tell the destination node to remove a specific node from its DB, by node number or ID",
-        metavar=["!XXXXXXXX", "0xXXXXXXXX"]
+        metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(
         "--set-favorite-node",
         help="Tell the destination node to set the specified node to be favorited on the NodeDB on the devicein its DB, by number or ID",
-        metavar=["!XXXXXXXX", "0xXXXXXXXX"]
+        metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(
         "--remove-favorite-node",
         help="Tell the destination node to set the specified node to be un-favorited on the NodeDB on the device, by number or ID",
-        metavar=["!XXXXXXXX", "0xXXXXXXXX"]
+        metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(
         "--set-ignored-node",
         help="Tell the destination node to set the specified node to be ignored on the NodeDB on the devicein its DB, by number or ID",
-        metavar=["!XXXXXXXX", "0xXXXXXXXX"]
+        metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(
         "--remove-ignored-node",
         help="Tell the destination node to set the specified node to be un-ignored on the NodeDB on the device, by number or ID",
-        metavar=["!XXXXXXXX", "0xXXXXXXXX"]
+        metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(
         "--reset-nodedb",

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1344,7 +1344,7 @@ def addSelectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         "--dest",
         help="The destination node id for any sent commands, if not set '^all' or '^local' is assumed as appropriate",
         default=None,
-        metavar=("!XXXXXXXX", "0xXXXXXXXX"),
+        metavar="!XXXXXXXX",
     )
 
     group.add_argument(
@@ -1648,7 +1648,7 @@ def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
         "You need pass the destination ID as argument, like "
         "this: '--traceroute !ba4bf9d0' "
         "Only nodes with a shared channel can be traced.",
-        metavar=("!XXXXXXXX", "0xXXXXXXXX"),
+        metavar="!XXXXXXXX"
     )
 
     group.add_argument(
@@ -1728,17 +1728,17 @@ def addRemoteAdminArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     group.add_argument(
         "--remove-node",
         help="Tell the destination node to remove a specific node from its DB, by node number or ID",
-        metavar=("!XXXXXXXX", "0xXXXXXXXX")
+        metavar="!XXXXXXXX"
     )
     group.add_argument(
         "--set-favorite-node",
         help="Tell the destination node to set the specified node to be favorited on the NodeDB on the devicein its DB, by number or ID",
-        metavar=("!XXXXXXXX", "0xXXXXXXXX")
+        metavar="!XXXXXXXX"
     )
     group.add_argument(
         "--remove-favorite-node",
         help="Tell the destination node to set the specified node to be un-favorited on the NodeDB on the device, by number or ID",
-        metavar=("!XXXXXXXX", "0xXXXXXXXX")
+        metavar="!XXXXXXXX"
     )
     group.add_argument(
         "--set-ignored-node",
@@ -1748,7 +1748,7 @@ def addRemoteAdminArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     group.add_argument(
         "--remove-ignored-node",
         help="Tell the destination node to set the specified node to be un-ignored on the NodeDB on the device, by number or ID",
-        metavar=("!XXXXXXXX", "0xXXXXXXXX")
+        metavar="!XXXXXXXX"
     )
     group.add_argument(
         "--reset-nodedb",

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1344,6 +1344,7 @@ def addSelectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         "--dest",
         help="The destination node id for any sent commands, if not set '^all' or '^local' is assumed as appropriate",
         default=None,
+        nargs=1,
         metavar=("!XXXXXXXX", "0xXXXXXXXX"),
     )
 
@@ -1648,6 +1649,7 @@ def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
         "You need pass the destination ID as argument, like "
         "this: '--traceroute !ba4bf9d0' "
         "Only nodes with a shared channel can be traced.",
+        nargs=1,
         metavar=("!XXXXXXXX", "0xXXXXXXXX"),
     )
 
@@ -1728,26 +1730,31 @@ def addRemoteAdminArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     group.add_argument(
         "--remove-node",
         help="Tell the destination node to remove a specific node from its DB, by node number or ID",
+        nargs=1,
         metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(
         "--set-favorite-node",
         help="Tell the destination node to set the specified node to be favorited on the NodeDB on the devicein its DB, by number or ID",
+        nargs=1,
         metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(
         "--remove-favorite-node",
         help="Tell the destination node to set the specified node to be un-favorited on the NodeDB on the device, by number or ID",
+        nargs=1,
         metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(
         "--set-ignored-node",
         help="Tell the destination node to set the specified node to be ignored on the NodeDB on the devicein its DB, by number or ID",
+        nargs=1,
         metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(
         "--remove-ignored-node",
         help="Tell the destination node to set the specified node to be un-ignored on the NodeDB on the device, by number or ID",
+        nargs=1,
         metavar=("!XXXXXXXX", "0xXXXXXXXX")
     )
     group.add_argument(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1344,7 +1344,6 @@ def addSelectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         "--dest",
         help="The destination node id for any sent commands, if not set '^all' or '^local' is assumed as appropriate",
         default=None,
-        nargs=1,
         metavar=("!XXXXXXXX", "0xXXXXXXXX"),
     )
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1344,7 +1344,7 @@ def addSelectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         "--dest",
         help="The destination node id for any sent commands, if not set '^all' or '^local' is assumed as appropriate",
         default=None,
-        metavar="!XXXXXXXX",
+        metavar="!xxxxxxxx",
     )
 
     group.add_argument(
@@ -1648,7 +1648,7 @@ def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
         "You need pass the destination ID as argument, like "
         "this: '--traceroute !ba4bf9d0' "
         "Only nodes with a shared channel can be traced.",
-        metavar="!XXXXXXXX"
+        metavar="!xxxxxxxx"
     )
 
     group.add_argument(
@@ -1728,27 +1728,27 @@ def addRemoteAdminArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     group.add_argument(
         "--remove-node",
         help="Tell the destination node to remove a specific node from its DB, by node number or ID",
-        metavar="!XXXXXXXX"
+        metavar="!xxxxxxxx"
     )
     group.add_argument(
         "--set-favorite-node",
         help="Tell the destination node to set the specified node to be favorited on the NodeDB on the devicein its DB, by number or ID",
-        metavar="!XXXXXXXX"
+        metavar="!xxxxxxxx"
     )
     group.add_argument(
         "--remove-favorite-node",
         help="Tell the destination node to set the specified node to be un-favorited on the NodeDB on the device, by number or ID",
-        metavar="!XXXXXXXX"
+        metavar="!xxxxxxxx"
     )
     group.add_argument(
         "--set-ignored-node",
         help="Tell the destination node to set the specified node to be ignored on the NodeDB on the devicein its DB, by number or ID",
-        metavar="!XXXXXXXX"
+        metavar="!xxxxxxxx"
     )
     group.add_argument(
         "--remove-ignored-node",
         help="Tell the destination node to set the specified node to be un-ignored on the NodeDB on the device, by number or ID",
-        metavar="!XXXXXXXX"
+        metavar="!xxxxxxxx"
     )
     group.add_argument(
         "--reset-nodedb",

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -226,7 +226,7 @@ def setPref(config, comp_name, raw_val) -> bool:
     logging.debug(f"valStr:{raw_val} val:{val}")
 
     if snake_name == "wifi_psk" and len(str(raw_val)) < 8:
-        print(f"Warning: network.wifi_psk must be 8 or more characters.")
+        print("Warning: network.wifi_psk must be 8 or more characters.")
         return False
 
     enumType = pref.enum_type
@@ -1342,7 +1342,8 @@ def addSelectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
 
     group.add_argument(
         "--dest",
-        help="The destination node id for any sent commands. Use prefix of ! or 0x. If not set '^all' or '^local' is assumed as appropriate.",
+        help="The destination node id for any sent commands. If not set '^all' or '^local' is assumed."
+        "Use the node ID with a '!' or '0x' prefix or the node number.",
         default=None,
         metavar="!xxxxxxxx",
     )
@@ -1727,27 +1728,32 @@ def addRemoteAdminArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
 
     group.add_argument(
         "--remove-node",
-        help="Tell the destination node to remove a specific node from its DB, by node number or ID",
+        help="Tell the destination node to remove a specific node from its NodeDB. "
+        "Use the node ID with a '!' or '0x' prefix or the node number.",
         metavar="!xxxxxxxx"
     )
     group.add_argument(
         "--set-favorite-node",
-        help="Tell the destination node to set the specified node to be favorited on the NodeDB on the devicein its DB, by number or ID using '!' or '0x' prefix.",
+        help="Tell the destination node to set the specified node to be favorited on the NodeDB. "
+        "Use the node ID with a '!' or '0x' prefix or the node number.",
         metavar="!xxxxxxxx"
     )
     group.add_argument(
         "--remove-favorite-node",
-        help="Tell the destination node to set the specified node to be un-favorited on the NodeDB on the device, by number or ID using '!' or '0x' prefix.",
+        help="Tell the destination node to set the specified node to be un-favorited on the NodeDB. "
+        "Use the node ID with a '!' or '0x' prefix or the node number.",
         metavar="!xxxxxxxx"
     )
     group.add_argument(
         "--set-ignored-node",
-        help="Tell the destination node to set the specified node to be ignored on the NodeDB on the devicein its DB, by number or ID using '!' or '0x' prefix.",
+        help="Tell the destination node to set the specified node to be ignored on the NodeDB. "
+        "Use the node ID with a '!' or '0x' prefix or the node number.",
         metavar="!xxxxxxxx"
     )
     group.add_argument(
         "--remove-ignored-node",
-        help="Tell the destination node to set the specified node to be un-ignored on the NodeDB on the device, by number or ID using '!' or '0x' prefix.",
+        help="Tell the destination node to set the specified node to be un-ignored on the NodeDB. "
+        "Use the node ID with a '!' or '0x' prefix or the node number.",
         metavar="!xxxxxxxx"
     )
     group.add_argument(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1344,7 +1344,7 @@ def addSelectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         "--dest",
         help="The destination node id for any sent commands, if not set '^all' or '^local' is assumed as appropriate",
         default=None,
-        metavar="!xxxxxxxx",
+        metavar=["!XXXXXXXX", "0xXXXXXXXX"],
     )
 
     group.add_argument(
@@ -1648,7 +1648,7 @@ def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
         "You need pass the destination ID as argument, like "
         "this: '--traceroute !ba4bf9d0' "
         "Only nodes with a shared channel can be traced.",
-        metavar="!xxxxxxxx",
+        metavar=["!XXXXXXXX", "0xXXXXXXXX"],
     )
 
     group.add_argument(
@@ -1728,27 +1728,27 @@ def addRemoteAdminArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     group.add_argument(
         "--remove-node",
         help="Tell the destination node to remove a specific node from its DB, by node number or ID",
-        metavar="!xxxxxxxx"
+        metavar=["!XXXXXXXX", "0xXXXXXXXX"]
     )
     group.add_argument(
         "--set-favorite-node",
         help="Tell the destination node to set the specified node to be favorited on the NodeDB on the devicein its DB, by number or ID",
-        metavar="!xxxxxxxx"
+        metavar=["!XXXXXXXX", "0xXXXXXXXX"]
     )
     group.add_argument(
         "--remove-favorite-node",
         help="Tell the destination node to set the specified node to be un-favorited on the NodeDB on the device, by number or ID",
-        metavar="!xxxxxxxx"
+        metavar=["!XXXXXXXX", "0xXXXXXXXX"]
     )
     group.add_argument(
         "--set-ignored-node",
         help="Tell the destination node to set the specified node to be ignored on the NodeDB on the devicein its DB, by number or ID",
-        metavar="!xxxxxxxx"
+        metavar=["!XXXXXXXX", "0xXXXXXXXX"]
     )
     group.add_argument(
         "--remove-ignored-node",
         help="Tell the destination node to set the specified node to be un-ignored on the NodeDB on the device, by number or ID",
-        metavar="!xxxxxxxx"
+        metavar=["!XXXXXXXX", "0xXXXXXXXX"]
     )
     group.add_argument(
         "--reset-nodedb",

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1342,7 +1342,7 @@ def addSelectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
 
     group.add_argument(
         "--dest",
-        help="The destination node id for any sent commands, if not set '^all' or '^local' is assumed as appropriate",
+        help="The destination node id for any sent commands. Use prefix of ! or 0x. If not set '^all' or '^local' is assumed as appropriate.",
         default=None,
         metavar="!xxxxxxxx",
     )
@@ -1646,7 +1646,7 @@ def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
         "--traceroute",
         help="Traceroute from connected node to a destination. "
         "You need pass the destination ID as argument, like "
-        "this: '--traceroute !ba4bf9d0' "
+        "this: '--traceroute !ba4bf9d0' | '--traceroute 0xba4bf9d0'"
         "Only nodes with a shared channel can be traced.",
         metavar="!xxxxxxxx",
     )
@@ -1732,22 +1732,22 @@ def addRemoteAdminArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     )
     group.add_argument(
         "--set-favorite-node",
-        help="Tell the destination node to set the specified node to be favorited on the NodeDB on the devicein its DB, by number or ID",
+        help="Tell the destination node to set the specified node to be favorited on the NodeDB on the devicein its DB, by number or ID using '!' or '0x' prefix.",
         metavar="!xxxxxxxx"
     )
     group.add_argument(
         "--remove-favorite-node",
-        help="Tell the destination node to set the specified node to be un-favorited on the NodeDB on the device, by number or ID",
+        help="Tell the destination node to set the specified node to be un-favorited on the NodeDB on the device, by number or ID using '!' or '0x' prefix.",
         metavar="!xxxxxxxx"
     )
     group.add_argument(
         "--set-ignored-node",
-        help="Tell the destination node to set the specified node to be ignored on the NodeDB on the devicein its DB, by number or ID",
+        help="Tell the destination node to set the specified node to be ignored on the NodeDB on the devicein its DB, by number or ID using '!' or '0x' prefix.",
         metavar="!xxxxxxxx"
     )
     group.add_argument(
         "--remove-ignored-node",
-        help="Tell the destination node to set the specified node to be un-ignored on the NodeDB on the device, by number or ID",
+        help="Tell the destination node to set the specified node to be un-ignored on the NodeDB on the device, by number or ID using '!' or '0x' prefix.",
         metavar="!xxxxxxxx"
     )
     group.add_argument(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1648,7 +1648,7 @@ def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
         "You need pass the destination ID as argument, like "
         "this: '--traceroute !ba4bf9d0' "
         "Only nodes with a shared channel can be traced.",
-        metavar="!xxxxxxxx"
+        metavar="!xxxxxxxx",
     )
 
     group.add_argument(

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -472,10 +472,10 @@ class MeshInterface:  # pylint: disable=R0902
         # issue 464: allow for 0x prefix in destinationId for hex values
         # destination ids can either be integers or strings with a !prefix
         try:
-            # sometimes the destinationId is actually a int as a string, so doing a type() check won't work
+            # sometimes the destinationId is actually an int as a string, so doing a type() check won't work
             int(destinationId)
         except ValueError:
-            # only take the last 8 characters of the destinationId and force a ! prefix
+            # only take the last 8 characters of the hexadecimal destinationId and force a ! prefix
             destinationId = f'!{destinationId[-8:]}'
 
         if getattr(data, "SerializeToString", None):

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -469,6 +469,11 @@ class MeshInterface:  # pylint: disable=R0902
         and can be used to track future message acks/naks.
         """
 
+        # issue 464: allow for 0x prefix in destinationId for hex values
+        if type(destinationId) == str:
+            destinationId = destinationId.replace('0x', '!')
+        logging.debug(f'destinationId: {destinationId}')
+
         if getattr(data, "SerializeToString", None):
             logging.debug(f"Serializing protobuf as data: {stripnl(data)}")
             data = data.SerializeToString()

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -469,15 +469,6 @@ class MeshInterface:  # pylint: disable=R0902
         and can be used to track future message acks/naks.
         """
 
-        # issue 464: allow for 0x prefix in destinationId for hex values
-        # destination ids can either be integers or strings with a !prefix
-        try:
-            # sometimes the destinationId is actually an int as a string, so doing a type() check won't work
-            int(destinationId)
-        except ValueError:
-            # only take the last 8 characters of the hexadecimal destinationId and force a ! prefix
-            destinationId = f'!{destinationId[-8:]}'
-
         if getattr(data, "SerializeToString", None):
             logging.debug(f"Serializing protobuf as data: {stripnl(data)}")
             data = data.SerializeToString()

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -472,6 +472,7 @@ class MeshInterface:  # pylint: disable=R0902
         # issue 464: allow for 0x prefix in destinationId for hex values
         # destination ids can either be integers or strings with a !prefix
         try:
+            # sometimes the destinationId is actually a int as a string, so doing a type() check won't work
             int(destinationId)
         except ValueError:
             # only take the last 8 characters of the destinationId and force a ! prefix

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -892,7 +892,7 @@ class MeshInterface:  # pylint: disable=R0902
             else:
                 our_exit("Warning: No myInfo found.")
         # A simple hex style nodeid - we can parse this without needing the DB
-        elif isinstance(destinationId, str) and len(destinationId) > 8:
+        elif isinstance(destinationId, str) and len(destinationId) >= 8:
             # assuming some form of node id string such as !1234578 or 0x12345678
             # always grab the last 8 items of the hexadecimal id str and parse to integer
             nodeNum = int(destinationId[-8:], 16)

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -345,7 +345,7 @@ class MeshInterface:  # pylint: disable=R0902
                         if new_index != last_index:
                             retries_left = requestChannelAttempts - 1
                         if retries_left <= 0:
-                            our_exit(f"Error: Timed out waiting for channels, giving up")
+                            our_exit("Error: Timed out waiting for channels, giving up")
                         print("Timed out trying to retrieve channel info, retrying")
                         n.requestChannels(startingIndex=new_index)
                         last_index = new_index
@@ -929,7 +929,7 @@ class MeshInterface:  # pylint: disable=R0902
         toRadio.packet.CopyFrom(meshPacket)
         if self.noProto:
             logging.warning(
-                f"Not sending packet because protocol use is disabled by noProto"
+                "Not sending packet because protocol use is disabled by noProto"
             )
         else:
             logging.debug(f"Sending packet: {stripnl(meshPacket)}")

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -470,9 +470,13 @@ class MeshInterface:  # pylint: disable=R0902
         """
 
         # issue 464: allow for 0x prefix in destinationId for hex values
-        if type(destinationId) == str:
-            destinationId = destinationId.replace('0x', '!')
-        logging.debug(f'destinationId: {destinationId}')
+        # destination ids can either be integers or strings with a !prefix
+        try:
+            int(destinationId)
+        except ValueError:
+            # only take the last 8 characters of the destinationId and force a ! prefix
+            destinationId = f'!{destinationId[-8:]}'
+        logging.info(f"Formatted destinationId: {destinationId}")
 
         if getattr(data, "SerializeToString", None):
             logging.debug(f"Serializing protobuf as data: {stripnl(data)}")

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -892,8 +892,10 @@ class MeshInterface:  # pylint: disable=R0902
             else:
                 our_exit("Warning: No myInfo found.")
         # A simple hex style nodeid - we can parse this without needing the DB
-        elif destinationId.startswith("!"):
-            nodeNum = int(destinationId[1:], 16)
+        elif isinstance(destinationId, str) and len(destinationId) > 8:
+            # assuming some form of node id string such as !1234578 or 0x12345678
+            # always grab the last 8 items of the hexadecimal id str and parse to integer
+            nodeNum = int(destinationId[-8:], 16)
         else:
             if self.nodes:
                 node = self.nodes.get(destinationId)

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -476,7 +476,6 @@ class MeshInterface:  # pylint: disable=R0902
         except ValueError:
             # only take the last 8 characters of the destinationId and force a ! prefix
             destinationId = f'!{destinationId[-8:]}'
-        logging.info(f"Formatted destinationId: {destinationId}")
 
         if getattr(data, "SerializeToString", None):
             logging.debug(f"Serializing protobuf as data: {stripnl(data)}")

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -1118,7 +1118,7 @@ class MeshInterface:  # pylint: disable=R0902
         """Send a ToRadio protobuf to the device"""
         if self.noProto:
             logging.warning(
-                f"Not sending packet because protocol use is disabled by noProto"
+                "Not sending packet because protocol use is disabled by noProto"
             )
         else:
             # logging.debug(f"Sending toRadio: {stripnl(toRadio)}")


### PR DESCRIPTION
A potential answer to [issue 464](https://github.com/meshtastic/python/issues/464). This allows users to run commands using a different prefix (`0x`) from the meshtastic CLI.

The code change here checks for if the node ID supplied can be turned into an int or not. If so, just pass the node id directly in. If not, it must be a string. Grab the last 8 characters of the node id and force-format the id to have a `!` prefix. That way users can provide any prefix they want to the meshtastic CLI.