### PR TITLE
448/SenderUnknownMsgDataError

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -1539,5 +1539,5 @@ class MeshInterface:  # pylint: disable=R0902
 
         logging.debug(f"Publishing {topic}: packet={stripnl(asDict)} ")
         publishingThread.queueWork(
-            lambda: pub.sendMessage(topic, packet=asDict, interface=self)
+            lambda: pub.sendMessage(topic, packet=asDict)
         )


### PR DESCRIPTION
in response to error code: pubsub.core.topicargspec.SenderUnknownMsgDataError: Some optional args unknown in call to sendMessage('('meshtastic', 'receive')', packet,interface): interface.

Full stack trace:
```2025-01-30 21:37:50 Eastern Standard Time - ERROR - Unexpected error in deferred execution <class 'pubsub.core.topicargspec.SenderUnknownMsgDataError'>
Traceback (most recent call last):
  File "\GitHub Projects\Meshtastic-Listener\venv\Lib\site-packages\meshtastic\util.py", line 309, in _run
    o()
    ~^^
  File "\GitHub Projects\Meshtastic-Listener\venv\Lib\site-packages\meshtastic\mesh_interface.py", line 1541, in <lambda>
    lambda: pub.sendMessage(topic, packet=asDict, interface=self)
            ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\GitHub Projects\Meshtastic-Listener\venv\Lib\site-packages\pubsub\core\publisher.py", line 216, in sendMessage
    topicObj.publish(**msgData)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "\GitHub Projects\Meshtastic-Listener\venv\Lib\site-packages\pubsub\core\topicobj.py", line 433, in publish
    self._getListenerSpec().check(msgData)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "\Meshtastic-Listener\venv\Lib\site-packages\pubsub\core\topicargspec.py", line 229, in check
    raise SenderUnknownMsgDataError(self.topicNameTuple,
                                    list(msgData.keys()), optional - set(self.allOptional))
pubsub.core.topicargspec.SenderUnknownMsgDataError: Some optional args unknown in call to sendMessage('('meshtastic', 'receive')', packet,interface): interface
```