### PR TITLE
catch unhandled OSError when serial port in use

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1255,6 +1255,12 @@ def common():
                     message += "  After running that command, log out and re-login for it to take effect.\n"
                     message += f"Error was:{ex}"
                     meshtastic.util.our_exit(message)
+                except OSError as ex:
+                    message = f"OS Error:\n"
+                    message += "  The serial device couldn't be opened, it might be in use by another process.\n"
+                    message += "  Please close any applications or webpages that may be using the device and try again.\n"
+                    message += f"\nOriginal error: {ex}"
+                    meshtastic.util.our_exit(message)
                 if client.devPath is None:
                     try:
                         client = meshtastic.tcp_interface.TCPInterface(


### PR DESCRIPTION
Existing crash:
```
Traceback (most recent call last):
  File "/opt/homebrew/bin/meshtastic", line 8, in <module>
    sys.exit(main())
  File "/opt/homebrew/lib/python3.9/site-packages/meshtastic/__main__.py", line 1988, in main
    common()
  File "/opt/homebrew/lib/python3.9/site-packages/meshtastic/__main__.py", line 1242, in common
    client = meshtastic.serial_interface.SerialInterface(
  File "/opt/homebrew/lib/python3.9/site-packages/meshtastic/serial_interface.py", line 52, in __init__
    with open(self.devPath, encoding="utf8") as f:
OSError: [Errno 16] Resource busy: '/dev/cu.usbserial-0001'
```

with updated catch:
```
OS Error:
  The serial device couldn't be opened, it might be in use by another process.
  Please close any applications or webpages that may be using the device and try again.

Original error: [Errno 16] Resource busy: '/dev/cu.usbserial-0001'
```