### PR TITLE
Added example script : meshtastic_serial_message_reader.py

### DIFF
--- a/examples/meshtastic_serial_message_reader.py
+++ b/examples/meshtastic_serial_message_reader.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+#
+# Released Under GNU GPLv3
+# Copyright 2025 Henri Shustak
+#
+# About :
+#    This script will print messages as they arrive from a meshtastic node connected via serial port USB.
+#    If you have multiple nodes attached, you will need to edit this script and specify the node to monitor.
+#    https://gist.github.com/henri/a6584d55813f971e5b1a4ee940c07d25
+#
+# Requirements : 
+#    You will need to install python meshtastic libraries : https://github.com/meshtastic/python
+#
+# Version History :
+#    1.0 - initial release
+#    1.1 - added support for sender id and bug fixs
+
+import time
+import meshtastic
+import meshtastic.serial_interface
+from pubsub import pub
+
+def onReceive(packet, interface):
+    # DEBUGGING
+    # print(f"message arrived")
+    # print(f"{packet}")
+    try:
+        if packet['decoded']['portnum'] == 'TEXT_MESSAGE_APP':
+            message = packet['decoded']['text']
+            channel_num = packet['channel']
+            sender_id = packet['fromId']
+            print(f"{channel_num} : {sender_id}  :  {message}")
+    except KeyError as e:
+        print(f"unable to decode message")
+        return
+
+#pub.subscribe(onReceive, "meshtastic.receive.text")
+pub.subscribe(onReceive, "meshtastic.receive")
+
+# try to find a meshtastic device, otherwise provide a device path like /dev/ttyUSB0
+interface = meshtastic.serial_interface.SerialInterface()
+
+while True:
+    time.sleep(10)  # wait for the next message
+

--- a/examples/meshtastic_serial_message_reader.py
+++ b/examples/meshtastic_serial_message_reader.py
@@ -6,16 +6,18 @@
 # About :
 #    This script will print messages as they arrive from a meshtastic node connected via serial port USB.
 #    If you have multiple nodes attached, you will need to edit this script and specify the node to monitor.
-#    https://gist.github.com/henri/a6584d55813f971e5b1a4ee940c07d25
 #
-# Requirements : 
+# Requirements :
 #    You will need to install python meshtastic libraries : https://github.com/meshtastic/python
 #
 # Version History :
 #    1.0 - initial release
-#    1.1 - added support for sender id and bug fixs
+#    1.1 - added support for sender id and bug fixes
+#    1.2 - added date and time reporting to each message
+#    1.3 - bug fixes and improved error handling
 
 import time
+from datetime import datetime, timezone
 import meshtastic
 import meshtastic.serial_interface
 from pubsub import pub
@@ -24,22 +26,33 @@ def onReceive(packet, interface):
     # DEBUGGING
     # print(f"message arrived")
     # print(f"{packet}")
+    # print(f"-----------------------------------------------------------------")
     try:
         if packet['decoded']['portnum'] == 'TEXT_MESSAGE_APP':
-            message = packet['decoded']['text']
-            channel_num = packet['channel']
-            sender_id = packet['fromId']
-            print(f"{channel_num} : {sender_id}  :  {message}")
-    except KeyError as e:
-        print(f"unable to decode message")
+            try:
+                message = packet['decoded']['text']
+                try:
+                    channel_num = packet['channel']
+                except KeyError as e1:
+                    channel_num = 0
+                sender_id = packet['fromId']
+                message_time = datetime.now().strftime(f"%a %b %d %Y %H:%M:%S {tz_name}")
+                print(f"{message_time} : {channel_num} : {sender_id}  :  {message}")
+            except KeyError as e2:
+                print(f"unable to decode message")
+                return
+    except KeyError as e3:
         return
 
+# configure the local time zone
+tz_name = time.tzname[time.localtime().tm_isdst > 0]
+
+# registrer for incomming messages
 #pub.subscribe(onReceive, "meshtastic.receive.text")
 pub.subscribe(onReceive, "meshtastic.receive")
 
-# try to find a meshtastic device, otherwise provide a device path like /dev/ttyUSB0
+# attempt to locate a meshtastic device, otherwise provide a device path like /dev/ttyUSB0
 interface = meshtastic.serial_interface.SerialInterface()
 
 while True:
     time.sleep(10)  # wait for the next message
-


### PR DESCRIPTION
Basic example script so you can see messages on a node attached via USB on LINUX. It may work with other connection types and on other operating systems. Your millage will vary. Contributions welcome to improve / expand / extend / modify etc.