### PR TITLE
Fix pytest test collection on default install

### DIFF
--- a/meshtastic/tests/test_analysis.py
+++ b/meshtastic/tests/test_analysis.py
@@ -6,7 +6,11 @@ import sys
 
 import pytest
 
-from meshtastic.analysis.__main__ import main
+try:
+    # Depends upon matplotlib & other packages in poetry's analysis group, not installed by default
+    from meshtastic.analysis.__main__ import main
+except ImportError:
+    pytest.skip("Can't import meshtastic.analysis", allow_module_level=True)
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -11,8 +11,12 @@ from ..protobuf import mesh_pb2, config_pb2
 from .. import BROADCAST_ADDR, LOCAL_ADDR
 from ..mesh_interface import MeshInterface, _timeago
 from ..node import Node
-from ..slog import LogSet
-from ..powermon import SimPowerSupply
+try:
+    # Depends upon the powermon group, not installed by default
+    from ..slog import LogSet
+    from ..powermon import SimPowerSupply
+except ImportError:
+    pytest.skip("Can't import LogSet or SimPowerSupply", allow_module_level=True)
 
 # TODO
 # from ..config import Config

--- a/meshtastic/tests/test_tunnel.py
+++ b/meshtastic/tests/test_tunnel.py
@@ -9,7 +9,11 @@ import pytest
 from meshtastic import mt_config
 
 from ..tcp_interface import TCPInterface
-from ..tunnel import Tunnel, onTunnelReceive
+try:
+    # Depends upon pytap2, not installed by default
+    from ..tunnel import Tunnel, onTunnelReceive
+except ImportError:
+    pytest.skip("Can't import Tunnel or onTunnelReceive", allow_module_level=True)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
As is, with a default `poetry install`, a simple `poetry pytest run` will encouter import errors while reading the test files themselves -- which causes pytest to fatally error during test collection, meaning no tests are run.