### PR TITLE
Allow forced UTF-8 encoding for --export-config

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1468,7 +1468,7 @@ def addImportExportArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
         help="Specify a path to a yaml(.yml) file containing the desired settings for the connected device.",
         action="append",
     )
-    parser.add_argument(
+    group.add_argument(
         "--export-config",
         nargs="?",
         const="-",  # default to "-" if no value provided

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -751,7 +751,7 @@ def onConnected(interface):
                 interface.getNode(args.dest, False, **getNode_kwargs).commitSettingsTransaction()
                 print("Writing modified configuration to device")
 
-        if args.export_config is not None:
+        if args.export_config:
             if args.dest != BROADCAST_ADDR:
                 print("Exporting configuration of remote nodes is not supported.")
                 return

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -1738,7 +1738,8 @@ position_broadcast_smart: true
 fixed_position: true
 position_flags: 35"""
         export_config(mo)
-    out, err = capsys.readouterr()
+    out = export_config(mo)
+    err = ""
 
     # ensure we do not output this line
     assert not re.search(r"Connected to radio", out, re.MULTILINE)


### PR DESCRIPTION
This PR changes the --export-config command to save a UTF-8 encoded file instead of printing to stdout.  Allows the legacy use of > to redirect to a file.

To fix incorrect encoding on Windows Powershell:
```bash
meshtastic --export-config file.yaml
```
Also allow:
```bash
meshtastic --export-config > file.yaml
```

closes #728 