### PR TITLE
Add seeed xiao esp32s3 support

### DIFF
--- a/meshtastic/supported_device.py
+++ b/meshtastic/supported_device.py
@@ -207,6 +207,18 @@ nano_g1 = SupportedDevice(
     usb_product_id_in_hex="55d4",
 )
 
+seeed_xiao_s3 = SupportedDevice(
+    name = "Seeed Xiao ESP32-S3",
+    version = "",
+    for_firmware="seeed-xiao-esp32s3",
+    baseport_on_linux="ttyACM",
+    baseport_on_mac="cu.usbmodem",
+    usb_vendor_id_in_hex="2886",
+    usb_product_id_in_hex="0059",
+)
+
+
+
 supported_devices = [
     tbeam_v0_7,
     tbeam_v1_1,
@@ -226,4 +238,5 @@ supported_devices = [
     rak4631_19003,
     rak11200,
     nano_g1,
+    seeed_xiao_s3,
 ]


### PR DESCRIPTION
esp32s3 version of seeed studio's xiao boards. The firmware also supports other xiao esp32 variants, and the xiao nrf52 variant, but I don't know the product ID for those models.