### PR TITLE
Add check for poetry install to regen-protobufs.sh

### DIFF
--- a/bin/regen-protobufs.sh
+++ b/bin/regen-protobufs.sh
@@ -6,6 +6,12 @@ set -e
 #gsed -i 's/import "\//import ".\//g' ./protobufs/meshtastic/*
 #gsed -i 's/package meshtastic;//g' ./protobufs/meshtastic/*
 
+POETRYDIR=$(poetry env info --path)
+
+if [[ -z "${POETRYDIR}" ]]; then
+	poetry install
+fi
+
 # protoc looks for mypy plugin in the python path
 source $(poetry env info --path)/bin/activate
 


### PR DESCRIPTION
This was failing in the CI because the poetry was not initialized.

Fixes https://github.com/meshtastic/python/issues/805