### PR TITLE
Export missing defaults when set False

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -262,7 +262,7 @@
       "module": "meshtastic",
       "justMyCode": true,
       "args": ["--nodes", "--show-fields", "AKA,Pubkey,Role,Role,Role,Latitude,Latitude,deviceMetrics.voltage"]
-    }
+    },
     {
       "name": "meshtastic --export-config",
       "type": "debugpy",
@@ -271,6 +271,5 @@
       "justMyCode": true,
       "args": ["--export-config", "config.json"]
     },
-
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
+
     {
       "name": "meshtastic BLE",
       "type": "debugpy",
@@ -262,6 +263,14 @@
       "justMyCode": true,
       "args": ["--nodes", "--show-fields", "AKA,Pubkey,Role,Role,Role,Latitude,Latitude,deviceMetrics.voltage"]
     }
+    {
+      "name": "meshtastic --export-config",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "meshtastic",
+      "justMyCode": true,
+      "args": ["--export-config", "config.json"]
+    },
 
   ]
 }

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1122,10 +1122,30 @@ def subscribe() -> None:
 
     # pub.subscribe(onNode, "meshtastic.node")
 
+def ensure_true_defaults(config_dict: dict, true_defaults: set[tuple[str, ...]]) -> None:
+    """Ensure that default=True keys are present in the config_dict and set to True."""
+    for path in true_defaults:
+        d = config_dict
+        for key in path[:-1]:
+            if key not in d or not isinstance(d[key], dict):
+                d[key] = {}
+            d = d[key]
+        if path[-1] not in d:
+            d[path[-1]] = True
 
 def export_config(interface) -> str:
     """used in --export-config"""
     configObj = {}
+
+    true_defaults = {
+        ("bluetooth", "enabled"),
+        ("lora", "sx126xRxBoostedGain"),
+        ("lora", "txEnabled"),
+        ("lora", "usePreset"),
+        ("position", "positionBroadcastSmartEnabled"),
+        ("security", "serialEnabled"),
+        ("mqtt", "encryptionEnabled"),
+    }
 
     owner = interface.getLongName()
     owner_short = interface.getShortName()
@@ -1184,6 +1204,8 @@ def export_config(interface) -> str:
             configObj["config"] = config		#Identical command here and 2 lines below?
         else:
             configObj["config"] = config
+
+        ensure_true_defaults(configObj["config"], true_defaults)
 
     module_config = MessageToDict(interface.localNode.moduleConfig)
     if module_config:

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1122,8 +1122,8 @@ def subscribe() -> None:
 
     # pub.subscribe(onNode, "meshtastic.node")
 
-def ensure_true_defaults(config_dict: dict, true_defaults: set[tuple[str, ...]]) -> None:
-    """Ensure that default=True keys are present in the config_dict and set to True."""
+def set_missing_flags_false(config_dict: dict, true_defaults: set[tuple[str, ...]]) -> None:
+    """Ensure that mission default=True keys are present in the config_dict and set to False."""
     for path in true_defaults:
         d = config_dict
         for key in path[:-1]:
@@ -1131,7 +1131,7 @@ def ensure_true_defaults(config_dict: dict, true_defaults: set[tuple[str, ...]])
                 d[key] = {}
             d = d[key]
         if path[-1] not in d:
-            d[path[-1]] = True
+            d[path[-1]] = False
 
 def export_config(interface) -> str:
     """used in --export-config"""
@@ -1205,7 +1205,7 @@ def export_config(interface) -> str:
         else:
             configObj["config"] = config
 
-        ensure_true_defaults(configObj["config"], true_defaults)
+        set_missing_flags_false(configObj["config"], true_defaults)
 
     module_config = MessageToDict(interface.localNode.moduleConfig)
     if module_config:


### PR DESCRIPTION
Some older protobufs default to True.  When users set them to False, they are excluded from --export-config.  When using --configure, these keys are not set to False.

This PR sets these keys to False in --export-config if they are missing.