### PR TITLE
Add cli option to export nodes

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1018,6 +1018,16 @@ def onConnected(interface):
             print("--show-fields can only be used with --nodes")
             return
 
+        if args.export_nodes:
+            closeNow = True
+            if args.dest != BROADCAST_ADDR:
+                print("Exporting nodes of a remote node is not supported.")
+                return
+            # Determine format from file extension
+            filename = args.export_nodes
+            format_type = "csv" if filename.lower().endswith('.csv') else "json"
+            interface.exportNodeDb(filename, format=format_type)
+
         if args.qr or args.qr_all:
             closeNow = True
             url = interface.getNode(args.dest, True, **getNode_kwargs).getURL(includeAll=args.qr_all)
@@ -1820,6 +1830,12 @@ def addLocalActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
         help="Specify fields to show (comma-separated) when using --nodes",
         type=lambda s: s.split(','),
         default=None
+    )
+
+    group.add_argument(
+        "--export-nodes",
+        help="Export node database to a file. Specify filename with .json or .csv extension to determine format (default: nodes.json)",
+        metavar="FILENAME",
     )
 
     return parser

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -3,6 +3,7 @@
 # pylint: disable=R0917,C0302
 
 import collections
+import csv
 import json
 import logging
 import math
@@ -374,6 +375,98 @@ class MeshInterface:  # pylint: disable=R0902
         table = tabulate(rows, headers="keys", missingval="N/A", tablefmt="fancy_grid")
         print(table)
         return table
+
+    def exportNodeDb(self, filename: str, format: str = "json") -> None:
+        """Export the node database to a file
+        
+        Args:
+            filename: Path to the output file
+            format: Export format - either "json" or "csv" (default: "json")
+        """
+        if not self.nodesByNum:
+            logger.warning("No nodes in database to export")
+            print("Warning: No nodes in database to export")
+            return
+        
+        # Prepare node data for export
+        nodes_data = []
+        for node in self.nodesByNum.values():
+            # Remove raw protobuf data and other non-serializable fields
+            keys_to_remove = ("raw", "decoded", "payload")
+            node_clean = remove_keys_from_dict(keys_to_remove, node.copy())
+            
+            # Flatten the structure for easier access
+            export_node = {
+                "num": node_clean.get("num"),
+                "user_id": node_clean.get("user", {}).get("id"),
+                "long_name": node_clean.get("user", {}).get("longName"),
+                "short_name": node_clean.get("user", {}).get("shortName"),
+                "hw_model": node_clean.get("user", {}).get("hwModel"),
+                "role": node_clean.get("user", {}).get("role"),
+                "latitude": node_clean.get("position", {}).get("latitude"),
+                "longitude": node_clean.get("position", {}).get("longitude"),
+                "altitude": node_clean.get("position", {}).get("altitude"),
+                "last_heard": node_clean.get("lastHeard"),
+                "snr": node_clean.get("snr"),
+                "hops_away": node_clean.get("hopsAway"),
+                "channel": node_clean.get("channel", 0),
+                "via_mqtt": node_clean.get("viaMqtt", False),
+                "is_favorite": node_clean.get("isFavorite", False),
+            }
+            
+            # Add device metrics if available
+            if "deviceMetrics" in node_clean:
+                metrics = node_clean["deviceMetrics"]
+                export_node["battery_level"] = metrics.get("batteryLevel")
+                export_node["voltage"] = metrics.get("voltage")
+                export_node["channel_utilization"] = metrics.get("channelUtilization")
+                export_node["air_util_tx"] = metrics.get("airUtilTx")
+            
+            nodes_data.append(export_node)
+        
+        # Export based on format
+        if format.lower() == "csv":
+            self._exportNodeDbCsv(filename, nodes_data)
+        else:
+            self._exportNodeDbJson(filename, nodes_data)
+    
+    def _exportNodeDbJson(self, filename: str, nodes_data: List[Dict]) -> None:
+        """Export node database as JSON"""
+        try:
+            with open(filename, 'w', encoding='utf-8') as f:
+                json.dump({
+                    "export_date": datetime.now().isoformat(),
+                    "nodes": nodes_data
+                }, f, indent=2)
+            print(f"Node database exported to {filename} ({len(nodes_data)} nodes)")
+            logger.info(f"Node database exported to {filename}")
+        except Exception as e:
+            logger.error(f"Failed to export node database: {e}")
+            print(f"Error: Failed to export node database: {e}")
+    
+    def _exportNodeDbCsv(self, filename: str, nodes_data: List[Dict]) -> None:
+        """Export node database as CSV"""
+        try:
+            if not nodes_data:
+                print("Warning: No nodes to export")
+                return
+            
+            # Get all possible field names
+            fieldnames = set()
+            for node in nodes_data:
+                fieldnames.update(node.keys())
+            fieldnames = sorted(fieldnames)
+            
+            with open(filename, 'w', newline='', encoding='utf-8') as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writeheader()
+                writer.writerows(nodes_data)
+            
+            print(f"Node database exported to {filename} ({len(nodes_data)} nodes)")
+            logger.info(f"Node database exported to {filename}")
+        except Exception as e:
+            logger.error(f"Failed to export node database: {e}")
+            print(f"Error: Failed to export node database: {e}")
 
     def getNode(
         self, nodeId: str, requestChannels: bool = True, requestChannelAttempts: int = 3, timeout: int = 300


### PR DESCRIPTION
# Add Node Database Export Feature

## Summary
This PR adds the ability to export the node database to JSON or CSV format, matching functionality available in the Android Meshtastic app. This enables users to backup, analyze, or share their mesh network's node information.

## Changes Made

### New CLI Command
- Added `--export-nodes FILENAME` argument to export node database
- Format is automatically detected from file extension (.json or .csv)
- Defaults to JSON format if extension is not recognized

### New API Methods
Added to `MeshInterface` class in `meshtastic/mesh_interface.py`:
- `exportNodeDb(filename, format)` - Main export method
- `_exportNodeDbJson(filename, nodes_data)` - JSON export handler
- `_exportNodeDbCsv(filename, nodes_data)` - CSV export handler

### Data Exported
Each node entry includes:
- Node identifiers: num, user_id, long_name, short_name
- Hardware: hw_model, role
- Location: latitude, longitude, altitude
- Metrics: snr, hops_away, channel, last_heard
- Device metrics (if available): battery_level, voltage, channel_utilization, air_util_tx
- Flags: via_mqtt, is_favorite

## Usage Examples

### Command Line Interface
```bash
# Export as JSON
meshtastic --export-nodes nodes.json

# Export as CSV  
meshtastic --export-nodes nodes.csv

# With specific device connection
meshtastic --port /dev/ttyUSB0 --export-nodes my_mesh.json
```

### Python API
```python
import meshtastic.serial_interface

interface = meshtastic.serial_interface.SerialInterface()
interface.exportNodeDb("nodes.json")  # JSON format
interface.exportNodeDb("nodes.csv", format="csv")  # CSV format
```

## Sample Output

### JSON Format
```json
{
  "export_date": "2025-10-09T23:20:00.000000",
  "nodes": [
    {
      "num": 862739652,
      "user_id": "!336db044",
      "long_name": "My Meshtastic Node",
      "short_name": "MSH1",
      "hw_model": "TBEAM",
      "latitude": 37.7749,
      "longitude": -122.4194,
      "altitude": 15,
      "last_heard": 1696882882,
      "snr": 8.5,
      "hops_away": 0,
      "battery_level": 85,
      "voltage": 4.1,
      "channel": 0,
      "via_mqtt": false,
      "is_favorite": false
    }
  ]
}
```

### CSV Format
Exports all fields as columns with headers for easy import into spreadsheet applications.

## Implementation Notes
- Uses existing node database structures from `MeshInterface.nodesByNum`
- Filters out raw protobuf data to ensure clean JSON/CSV output
- Gracefully handles missing fields (e.g., nodes without position data)
- Follows existing code patterns in the codebase

## Testing
Tested with:
- JSON export with various node configurations
- CSV export for spreadsheet analysis
- Syntax validation passes
- CLI help displays correctly

## Related
This feature mirrors functionality available in the Android Meshtastic app's node database download feature.
