### PR TITLE
flush() is only called if the stream is open

### DIFF
--- a/meshtastic/serial_interface.py
+++ b/meshtastic/serial_interface.py
@@ -85,10 +85,14 @@ class SerialInterface(StreamInterface):
 
     def close(self) -> None:
         """Close a connection to the device"""
-        if self.stream:  # Stream can be null if we were already closed
-            self.stream.flush()  # FIXME: why are there these  two flushes with 100ms sleeps?  This shouldn't be necessary
-            time.sleep(0.1)
-            self.stream.flush()
-            time.sleep(0.1)
+        if hasattr(self, "stream") and self.stream and getattr(self.stream, "is_open", False):
+            try:
+                self.stream.flush()
+                time.sleep(0.1)
+                # FIXME: why are there these  two flushes with 100ms sleeps?  This shouldn't be necessary
+                self.stream.flush()
+                time.sleep(0.1)
+            except Exception as e:
+                logger.debug(f"Exception during flush: {e}")
         logger.debug("Closing Serial stream")
         StreamInterface.close(self)


### PR DESCRIPTION
This ensures flush() is only called if the stream is open, and logs (but ignores) any exceptions during flush. This should prevent the "Bad file descriptor" error.

I see this error a lot on a rak unit, I dont know this is the way but .. you be the judge.