### PR TITLE
Container: Add initial container for meshtastic-cli

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+*
+!Containerfile*
+!Dockerfile
+!README.md
+!bin/container-entrypoint.sh
+!examples/
+!extra/
+!meshtastic/
+!poetry.lock
+!pyproject.toml

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -1,0 +1,77 @@
+name: Create and publish Container image
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*.*.*'
+  pull_request:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - container: Containerfile.debian
+            autotag: false
+            suffix: -debian
+          - container: Containerfile.alpine
+            autotag: ${{ github.ref == 'refs/heads/master' && 'true' || 'auto' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=edge
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          flavor: |
+            latest=${{ matrix.autotag }}
+            suffix=${{ matrix.suffix }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
+          context: .
+          file: ${{ matrix.container }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,1 @@
+Containerfile.alpine

--- a/Containerfile.alpine
+++ b/Containerfile.alpine
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Olliver Schinagl <oliver@schinagl.nl>
+
+ARG TARGET_VERSION="3.11-alpine"
+ARG TARGET_ARCH="library"
+
+FROM docker.io/${TARGET_ARCH}/python:${TARGET_VERSION}
+
+WORKDIR /usr/local/app
+
+COPY . /usr/local/app
+
+RUN _poetry_venv_dir="$(mktemp -d -p "${TMPDIR:-/tmp}" 'poetry_venv.XXXXXX')" && \
+    python -m 'venv' "${_poetry_venv_dir}" && \
+    "${_poetry_venv_dir}/bin/pip" install 'poetry' && \
+    "${_poetry_venv_dir}/bin/poetry" config --local virtualenvs.create false && \
+    "${_poetry_venv_dir}/bin/poetry" install && \
+    rm -f -r "${_poetry_venv_dir}" && \
+    rm -f -r "/usr/local/app"
+
+COPY "./bin/container-entrypoint.sh" "/init"
+
+ENTRYPOINT [ "/init" ]

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Olliver Schinagl <oliver@schinagl.nl>
+
+ARG TARGET_VERSION="3.11"
+ARG TARGET_ARCH="library"
+
+FROM docker.io/${TARGET_ARCH}/python:${TARGET_VERSION}
+
+WORKDIR /usr/local/app
+
+COPY . /usr/local/app
+
+RUN _poetry_venv_dir="$(mktemp -d -p "${TMPDIR:-/tmp}" 'poetry_venv.XXXXXX')" && \
+    python -m 'venv' "${_poetry_venv_dir}" && \
+    "${_poetry_venv_dir}/bin/pip" install 'poetry' && \
+    "${_poetry_venv_dir}/bin/poetry" config --local virtualenvs.create false && \
+    "${_poetry_venv_dir}/bin/poetry" install --no-directory && \
+    rm -f -r "${_poetry_venv_dir}" && \
+    rm -f -r "/usr/local/app"
+
+COPY "./bin/container-entrypoint.sh" "/init"
+
+ENTRYPOINT [ "/init" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+Containerfile

--- a/bin/container-entrypoint.sh
+++ b/bin/container-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Olliver Schinagl <oliver@schinagl.nl>
+#
+# A beginning user should be able to docker run image bash (or sh) without
+# needing to learn about --entrypoint
+# https://github.com/docker-library/official-images#consistency
+
+set -eu
+
+bin='meshtastic'
+
+# run command if it is not starting with a "-" and is an executable in PATH
+if [ "${#}" -le 0 ] || \
+   [ "${1#-}" != "${1}" ] || \
+   [ -d "${1}" ] || \
+   ! command -v "${1}" > '/dev/null' 2>&1; then
+	entrypoint='true'
+fi
+
+exec ${entrypoint:+${bin:?}} "${@}"
+
+exit 0


### PR DESCRIPTION
Just a quick set of files to enable the build of (tagged) containers. Both alpine and debian containers are available (~200MiB/~1.2GiB) allowing us to use meshtastic cli with a quick docker run, instead of having to build/install stuff locally.