### PR TITLE
Make Serial and TCP interfaces more closely respect connectNow when false

### DIFF
--- a/meshtastic/serial_interface.py
+++ b/meshtastic/serial_interface.py
@@ -50,6 +50,11 @@ class SerialInterface(StreamInterface):
             else:
                 self.devPath = ports[0]
 
+        StreamInterface.__init__(
+            self, debugOut=debugOut, noProto=noProto, connectNow=connectNow, noNodes=noNodes, timeout=timeout
+        )
+
+    def connect(self) -> None:
         logger.debug(f"Connecting to {self.devPath}")
 
         if sys.platform != "win32":
@@ -63,9 +68,7 @@ class SerialInterface(StreamInterface):
         self.stream.flush()	# type: ignore[attr-defined]
         time.sleep(0.1)
 
-        StreamInterface.__init__(
-            self, debugOut=debugOut, noProto=noProto, connectNow=connectNow, noNodes=noNodes, timeout=timeout
-        )
+        super().connect()
 
     def _set_hupcl_with_termios(self, f: TextIOWrapper):
         """first we need to set the HUPCL so the device will not reboot based on RTS and/or DTR

--- a/meshtastic/serial_interface.py
+++ b/meshtastic/serial_interface.py
@@ -35,8 +35,6 @@ class SerialInterface(StreamInterface):
             debugOut {stream} -- If a stream is provided, any debug serial output from the device will be emitted to that stream. (default: {None})
             timeout -- How long to wait for replies (default: 300 seconds)
         """
-        self.noProto = noProto
-
         self.devPath: Optional[str] = devPath
 
         if self.devPath is None:

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -39,12 +39,11 @@ class StreamInterface(MeshInterface):
             timeout -- How long to wait for replies (default: 300 seconds)
 
         Raises:
-            Exception: [description]
-            Exception: [description]
+            RuntimeError: Raised if StreamInterface is instantiated when noProto is false.
         """
 
-        if not hasattr(self, "stream") and not noProto:
-            raise Exception( # pylint: disable=W0719
+        if not noProto and type(self) == StreamInterface:
+            raise RuntimeError(
                 "StreamInterface is now abstract (to update existing code create SerialInterface instead)"
             )
         self.stream: Optional[serial.Serial] # only serial uses this, TCPInterface overrides the relevant methods instead

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -46,7 +46,7 @@ class StreamInterface(MeshInterface):
             raise RuntimeError(
                 "StreamInterface is now abstract (to update existing code create SerialInterface instead)"
             )
-        self.stream: Optional[serial.Serial] # only serial uses this, TCPInterface overrides the relevant methods instead
+        self.stream: Optional[serial.Serial] = None  # only serial uses this, TCPInterface overrides the relevant methods instead
         self._rxBuf = bytes()  # empty
         self._wantExit = False
 

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -42,7 +42,7 @@ class StreamInterface(MeshInterface):
             RuntimeError: Raised if StreamInterface is instantiated when noProto is false.
         """
 
-        if not noProto and type(self) == StreamInterface:
+        if not noProto and type(self) == StreamInterface: # pylint: disable=C0123
             raise RuntimeError(
                 "StreamInterface is now abstract (to update existing code create SerialInterface instead)"
             )

--- a/meshtastic/tcp_interface.py
+++ b/meshtastic/tcp_interface.py
@@ -31,9 +31,6 @@ class TCPInterface(StreamInterface):
             hostname {string} -- Hostname/IP address of the device to connect to
             timeout -- How long to wait for replies (default: 300 seconds)
         """
-
-        self.stream = None
-
         self.hostname: str = hostname
         self.portNumber: int = portNumber
 

--- a/meshtastic/tcp_interface.py
+++ b/meshtastic/tcp_interface.py
@@ -36,11 +36,6 @@ class TCPInterface(StreamInterface):
 
         self.socket: Optional[socket.socket] = None
 
-        if connectNow:
-            self.myConnect()
-        else:
-            self.socket = None
-
         super().__init__(debugOut=debugOut, noProto=noProto, connectNow=connectNow, noNodes=noNodes, timeout=timeout)
 
     def __repr__(self):
@@ -65,8 +60,13 @@ class TCPInterface(StreamInterface):
         if self.socket is not None:
             self.socket.shutdown(socket.SHUT_RDWR)
 
+    def connect(self) -> None:
+        """Connect the interface"""
+        self.myConnect()
+        super().connect()
+
     def myConnect(self) -> None:
-        """Connect to socket"""
+        """Connect to socket (without attempting to start the interface's receive thread"""
         logger.debug(f"Connecting to {self.hostname}") # type: ignore[str-bytes-safe]
         server_address = (self.hostname, self.portNumber)
         self.socket = socket.create_connection(server_address)

--- a/meshtastic/tests/test_stream_interface.py
+++ b/meshtastic/tests/test_stream_interface.py
@@ -15,7 +15,7 @@ def test_StreamInterface():
     """Test that we cannot instantiate a StreamInterface based on noProto"""
     with pytest.raises(Exception) as pytest_wrapped_e:
         StreamInterface()
-    assert pytest_wrapped_e.type == Exception
+    assert pytest_wrapped_e.type == RuntimeError
 
 
 # Note: This takes a bit, so moving from unit to slow


### PR DESCRIPTION
**Background**
When the connectNow parameter to StreamInterface's init() method is True, it will also call connect() during init(). Then connect() starts a thread for receiving data and starts the process of pulling config info from the node.

**The issue**
When using classes that inherit from StreamInterface it should be possible to instantiate an interface but not "connectNow" and then later call connect() to create a connection.

Currently, when connectNow is false:
* SerialInterface still creates a serial connection in init() but doesn't call StreamInterface.connect().
* TCPInterface doesn't create a socket connection in init() but subsequently calling connect() on TCPInterface is ineffective because TCPInterface has its own myConnect() method that is independent of StreamInterface.connect().

Commit 2245ac8d970bf827b32b85eadce6d74ad5f03d2f moves the connection parts of SerialInterface's init() method out into a separate connect() method that does its bit and then calls connect() from StreamInterface (and which won't be called during init() if connectNow is false).

Commit 76418b8e574a3a216a572d6e720c5aa060a35512 similarly adds a connect() method that calls TCPInterface's myConnect() first before calling connect() from StreamInterface.

The other commits are incidental cleanups. f3f17a7d50b7b8f368de488f19b09b054d60916b and 3be73b42e219ab4c5235c77e417c7ee018357008 get rid of some variables that are already better declared elsewhere. 79334e83e6dc94c472a990849701fc372ca609cf and 040f332078085fc04710c63d67388fc0c7f07293 tidy up the way that the use of StreamInterface in a non-abstract way is blocked, by changing how that is checked for and issuing a RuntimeError instead of a generic exception (with a corresponding test case change).

These changes shouldn't break anything, except perhaps if anyone is already using a workaround for the issue in separate apps.
