### PR TITLE
Splitting out true_defaults for moduleConfig in export_config()

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1147,13 +1147,16 @@ def export_config(interface) -> str:
     configObj = {}
 
     # A list of configuration keys that should be set to False if they are missing
-    true_defaults = {
+    config_true_defaults = {
         ("bluetooth", "enabled"),
         ("lora", "sx126xRxBoostedGain"),
         ("lora", "txEnabled"),
         ("lora", "usePreset"),
         ("position", "positionBroadcastSmartEnabled"),
         ("security", "serialEnabled"),
+    }
+
+    module_true_defaults = {
         ("mqtt", "encryptionEnabled"),
     }
 
@@ -1215,7 +1218,7 @@ def export_config(interface) -> str:
         else:
             configObj["config"] = config
 
-        set_missing_flags_false(configObj["config"], true_defaults)
+        set_missing_flags_false(configObj["config"], config_true_defaults)
 
     module_config = MessageToDict(interface.localNode.moduleConfig)
     if module_config:
@@ -1228,6 +1231,8 @@ def export_config(interface) -> str:
             configObj["module_config"] = prefs
         else:
             configObj["module_config"] = prefs
+
+        set_missing_flags_false(configObj["module_config"], module_true_defaults)
 
     config_txt = "# start of Meshtastic configure yaml\n"		#checkme - "config" (now changed to config_out)
                                                                         #was used as a string here and a Dictionary above


### PR DESCRIPTION
**Background**
The output of export_config() normally omits config values that have been set to false, because most protobuf config settings default to false anyway and therefore don't normally need to be set to false. But because some config values may default to true, PR https://github.com/meshtastic/python/pull/807 adjusted things that so that where specified "true default" settings have been set false for the node, then those specified settings will still export as false when using export_config(). 

**The Issue**
* The specified setting for the mqtt module has been included as if MQTTConfig were contained in LocalConfig but it's actually contained in ModuleConfig. 
* This results in "mqtt: encryptionEnabled: false" always being present in the wrong section of the output of --export-config (which will then be ignored by --configure with a warning) and no mention of "mqtt: encryptionEnabled: false" in the correct section when it is set to false.

This adjustment adds a second "true_defaults" variable and set_missing_flags_false() call in relation to ModuleConfig, and sticks the mqtt default there.