### PR TITLE
Enhance get_channels_with_hash()

### DIFF
--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1023,7 +1023,7 @@ class Node:
     def get_channels_with_hash(self):
         """Return a list of dicts with channel info and hash."""
         result = []
-        def format_preset_name(name):
+        def format_preset_name(name='Custom'):
             # Convert name like MODEM_PRESET to ModemPreset
             return ''.join(word.capitalize() for word in name.split('_'))
 


### PR DESCRIPTION
To set the index 0 name to the preset name from localConfig.lora.modem_preset when empty

 and compute hash so the output will not have bad index0 name or hash, also removes all disabled for clarity. 

This outputs `Device1 Channel Hash Table: [{'index': 0, 'role': 'PRIMARY', 'name': 'LongFast', 'hash': 8}` for a LongFast