### PR TITLE
fix(cli): route --reply responses to the correct channel

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -87,10 +87,11 @@ def onReceive(packet, interface) -> None:
             if msg:
                 rxSnr = packet["rxSnr"]
                 hopLimit = packet["hopLimit"]
+                channelIndex = packet.get("channel", 0)
                 print(f"message: {msg}")
                 reply = f"got msg '{msg}' with rxSnr: {rxSnr} and hopLimit: {hopLimit}"
-                print("Sending reply: ", reply)
-                interface.sendText(reply)
+                print(f"Sending reply on channelIndex {mt_config.channel_index or 0}: {reply}")
+                interface.sendText(reply,channelIndex=channelIndex)
 
     except Exception as ex:
         print(f"Warning: Error processing received packet: {ex}.")


### PR DESCRIPTION
Ensures that automatic replies are sent back on the same channel index the message was received on. Previously, all replies defaulted to the primary channel (0), even if the incoming message arrived on a secondary channel.

Modified the `onReceive` handler to extract the `channel` index from received packets. This ensures `interface.sendText` targets the originating channel rather than always defaulting to the primary channel.