### PR TITLE
Filter --reply based on specified channel index

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -85,12 +85,18 @@ def onReceive(packet, interface) -> None:
         if d is not None and args and args.reply:
             msg = d.get("text")
             if msg:
-                rxSnr = packet["rxSnr"]
-                hopLimit = packet["hopLimit"]
-                print(f"message: {msg}")
-                reply = f"got msg '{msg}' with rxSnr: {rxSnr} and hopLimit: {hopLimit}"
-                print("Sending reply: ", reply)
-                interface.sendText(reply)
+                rxChannel = packet.get("channel", 0)
+                targetChannel = int(args.ch_index or 0)
+                if rxChannel == targetChannel:
+                    rxSnr = packet["rxSnr"]
+                    hopLimit = packet["hopLimit"]
+                    print(f"message: {msg}")
+                    reply = f"got msg '{msg}' with rxSnr: {rxSnr} and hopLimit: {hopLimit}"
+                    print(f"Received channel {rxChannel}. Sending reply: {reply}")
+                    interface.sendText(reply,channelIndex=rxChannel)
+                else:
+                    print(f"Ignored message on channel {rxChannel} (waiting for channel {targetChannel})")
+                    
 
     except Exception as ex:
         print(f"Warning: Error processing received packet: {ex}.")


### PR DESCRIPTION
<html><body>
<!--StartFragment--><p data-pm-slice="1 1 []">Fixes an issue where automatic replies generated by the <code>--reply</code> flag were incorrectly routed and unfiltered.</p><h3>Changes</h3><ol><li><p><strong>Channel Routing</strong>: Responses are now explicitly sent back on the same channel index the message was received on, rather than defaulting to the primary channel (0).</p></li><li><p><strong>Channel Filtering</strong>: The <code>--reply</code> action now respects the <code>--ch-index</code> flag. It will only trigger a response if the incoming message matches the user-specified channel.</p></li></ol><h3>Behavior Comparison</h3><p><strong>Command:</strong> <code>meshtastic --ch-index 1 --reply</code></p>

<table width="100%">
<thead>
<tr align="left">
<th>Scenario</th>
<th>Previous Behavior</th>
<th>New Behavior</th>
</tr>
</thead>
<tbody>
<tr>
<td><b>Msg received on Ch 0</b></td>
<td>Sent reply on Ch 0</td>
<td><i>Ignored</i> (No match)</td>
</tr>
<tr>
<td><b>Msg received on Ch 1</b></td>
<td>Sent reply on Ch 0</td>
<td><b>Sent reply on Ch 1</b></td>
</tr>
<tr>
<td><b>Msg received on Ch 2</b></td>
<td>Sent reply on Ch 0</td>
<td><i>Ignored</i> (No match)</td>
</tr>
</tbody>
</table>

<h3>Technical Implementation</h3><p>The <code>onReceive</code> handler now casts <code>args.ch_index</code> to an integer and performs a comparison against the <code>channel</code> field in the incoming packet before calling <code>interface.sendText()</code>.</p><!--EndFragment-->
</body>
</html>
