### PR TITLE
fix(ble): handle BLEError on init with user-friendly messages

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1365,13 +1365,60 @@ def common():
                     print(f"Found: name='{x.name}' address='{x.address}'")
                 meshtastic.util.our_exit("BLE scan finished", 0)
             elif args.ble:
-                client = BLEInterface(
-                    args.ble if args.ble != "any" else None,
-                    debugOut=logfile,
-                    noProto=args.noproto,
-                    noNodes=args.no_nodes,
-                    timeout=args.timeout,
-                )
+                try:
+                    client = BLEInterface(
+                        args.ble if args.ble != "any" else None,
+                        debugOut=logfile,
+                        noProto=args.noproto,
+                        noNodes=args.no_nodes,
+                        timeout=args.timeout,
+                    )
+                except BLEInterface.BLEError as e:
+                    msg = str(e)
+                    if "No Meshtastic BLE peripheral" in msg:
+                        meshtastic.util.our_exit(
+                            "BLE device not found.\n\n"
+                            "Possible causes:\n"
+                            "  - Bluetooth is disabled on the Meshtastic device\n"
+                            "  - Device is in deep sleep mode\n"
+                            "  - Device is out of range\n\n"
+                            "Try:\n"
+                            "  - Press the reset button on your device\n"
+                            "  - Run 'meshtastic --ble-scan' to see available devices",
+                            1,
+                        )
+                    elif "More than one" in msg:
+                        meshtastic.util.our_exit(
+                            "Multiple Meshtastic BLE devices found.\n\n"
+                            "Please specify which device to connect to:\n"
+                            "  - Run 'meshtastic --ble-scan' to list devices\n"
+                            "  - Use 'meshtastic --ble <name_or_address>' to connect",
+                            1,
+                        )
+                    elif "Error writing BLE" in msg:
+                        meshtastic.util.our_exit(
+                            "Failed to write to BLE device.\n\n"
+                            "Possible causes:\n"
+                            "  - Device requires pairing PIN (check device screen)\n"
+                            "  - On Linux: user not in 'bluetooth' group\n"
+                            "  - Connection was interrupted\n\n"
+                            "Try:\n"
+                            "  - Restart Bluetooth on your computer\n"
+                            "  - Reset the Meshtastic device",
+                            1,
+                        )
+                    elif "Error reading BLE" in msg:
+                        meshtastic.util.our_exit(
+                            "Failed to read from BLE device.\n\n"
+                            "The device may have disconnected unexpectedly.\n\n"
+                            "Try:\n"
+                            "  - Move closer to the device\n"
+                            "  - Reset the Meshtastic device\n"
+                            "  - Restart Bluetooth on your computer",
+                            1,
+                        )
+                    else:
+                        meshtastic.util.our_exit(f"BLE error: {e}", 1)
             elif args.host:
                 try:
                     if ":" in args.host:

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1474,6 +1474,23 @@ def common():
                     message += "  Please close any applications or webpages that may be using the device and try again.\n"
                     message += f"\nOriginal error: {ex}"
                     meshtastic.util.our_exit(message)
+                except MeshInterface.MeshInterfaceError as ex:
+                    msg = str(ex)
+                    if "Timed out" in msg:
+                        meshtastic.util.our_exit(
+                            "Connection timed out.\n\n"
+                            "Possible causes:\n"
+                            "  - Device is rebooting\n"
+                            "  - Device firmware is updating\n"
+                            "  - Serial connection was interrupted\n\n"
+                            "Try:\n"
+                            "  - Wait a few seconds and try again\n"
+                            "  - Check if device is fully booted (LED patterns)\n"
+                            "  - Reconnect the USB cable",
+                            1,
+                        )
+                    else:
+                        meshtastic.util.our_exit(f"Connection error: {ex}", 1)
                 if client.devPath is None:
                     try:
                         client = meshtastic.tcp_interface.TCPInterface(


### PR DESCRIPTION
## Summary

Replace raw Python tracebacks with helpful error messages when BLE and serial operations fail.

**Before:**
```
Traceback (most recent call last):
  File "meshtastic/__main__.py", line 1368, in common
    client = BLEInterface(...)
  ...
meshtastic.ble_interface.BLEInterface.BLEError: No Meshtastic BLE peripheral with identifier...
```

**After:**
```
BLE device not found.

Possible causes:
  - Bluetooth is disabled on the Meshtastic device
  - Device is in deep sleep mode
  - Device is out of range

Try:
  - Press the reset button on your device
  - Run 'meshtastic --ble-scan' to see available devices
```

## Changes

### BLE Error Handling
Wrap `BLEInterface()` constructor in try/except and provide context-aware error messages for:

- **Device not found** — BLE disabled, sleep mode, out of range
- **Multiple devices found** — need to specify which one
- **Write errors** — pairing PIN required, Linux bluetooth group
- **Read errors** — device disconnected unexpectedly

### Serial Error Handling
Handle `MeshInterface.MeshInterfaceError` for connection timeouts:

- **Connection timed out** — device rebooting, firmware updating, serial interrupted

## Test Plan

- [x] Run `meshtastic --ble nonexistent` — should show "device not found" message
- [x] Test with device in sleep mode — should show helpful suggestions
- [x] Test on Linux without bluetooth group membership
- [x] Test serial connection during device reboot — should show timeout message