### PR TITLE
Refactor the Meshtastic TCP pub/sub example to ensure proper resource cleanup and clearer exception handling.

### DIFF
--- a/examples/pub_sub_example2.py
+++ b/examples/pub_sub_example2.py
@@ -5,10 +5,9 @@
 import sys
 import time
 
-from pubsub import pub
+from meshtastic.tcp_interface import TCPInterface
 
-import meshtastic
-import meshtastic.tcp_interface
+from pubsub import pub
 
 # simple arg check
 if len(sys.argv) < 2:
@@ -29,11 +28,15 @@ def onConnection(interface, topic=pub.AUTO_TOPIC):  # pylint: disable=unused-arg
 
 pub.subscribe(onReceive, "meshtastic.receive")
 pub.subscribe(onConnection, "meshtastic.connection.established")
+
+iface=None
 try:
-    iface = meshtastic.tcp_interface.TCPInterface(hostname=sys.argv[1])
+    iface = TCPInterface(hostname=sys.argv[1])
     while True:
         time.sleep(1000)
-    iface.close()
 except Exception as ex:
     print(f"Error: Could not connect to {sys.argv[1]} {ex}")
-    sys.exit(1)
+    raise
+finally:
+    if iface:
+        iface.close()


### PR DESCRIPTION
What changed:

- Wrapped the TCP interface lifecycle in a try / finally block to guarantee that `TCPInterface.close()` is always called.
- Initialized `iface` to None to safely handle failures during interface creation.
- Replaced `sys.exit(1)` with re-raising the exception to preserve the original traceback.
- Simplified imports by importing `TCPInterface` directly.
- Kept the example behavior and public API unchanged.

Why:

- The original example never reached `iface.close()` due to the infinite loop and could leave the TCP connection open when interrupted or when an exception occurred.
- Using finally ensures deterministic cleanup and makes the example safer and easier to reason about, especially for users copying it into their own scripts.
- Re-raising the exception provides better diagnostics while still allowing finally to run.

Behavior impact:

- No functional changes to the demo logic.
- Improved reliability and correctness on errors or interruptions.
- More idiomatic Python resource handling.