### PR TITLE
Fix '--get security' (incorrect AdminMessage.ConfigType value).

### DIFF
--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -170,11 +170,10 @@ class Node:
             p.get_config_request = configType
 
         else:
-            msgIndex = configType.index
             if configType.containing_type.name == "LocalConfig":
-                p.get_config_request = msgIndex
+                p.get_config_request = admin_pb2.AdminMessage.ConfigType.Value(configType.name.upper() + "_CONFIG")
             else:
-                p.get_module_config_request = msgIndex
+                p.get_module_config_request = configType.index
 
         self._sendAdmin(p, wantResponse=True, onResponse=onResponse)
         if onResponse:


### PR DESCRIPTION
requestConfig was assuming that the order of fields in meshtastic.LocalConfig matches the order of enum values in AdminMessage.ConfigType. This is true for 'device', 'position', etc. but is NOT true for 'security' due to the intervening 'version' field.

Look up config fields by name, not index, to prevent this error in the future.

LocalConfig.security was introduced in https://github.com/meshtastic/protobufs/pull/553