### PR TITLE
Fix position overwrite by lower-precision data

### DIFF
--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -179,8 +179,30 @@ def _onPositionReceive(iface, asDict):
             logger.debug(f"p:{p}")
             p = iface._fixupPosition(p)
             logger.debug(f"after fixup p:{p}")
-            # update node DB as needed
-            iface._getOrCreateByNum(asDict["from"])["position"] = p
+            # For the local node, only accept position updates with equal
+            # or better precision. The local GPS is authoritative, and
+            # low-precision echoes from the mesh (e.g., map reports relayed
+            # by other nodes) should not overwrite it.
+            # For remote nodes, always accept the latest position since
+            # any update from them reflects their current state.
+            node = iface._getOrCreateByNum(asDict["from"])
+            is_local_node = (
+                iface.myInfo is not None
+                and asDict["from"] == iface.myInfo.my_node_num
+            )
+            if is_local_node:
+                existing = node.get("position", {})
+                existing_precision = existing.get("precisionBits", 0) or 0
+                new_precision = p.get("precisionBits", 0) or 0
+                if existing_precision == 0 or new_precision >= existing_precision:
+                    node["position"] = p
+                else:
+                    logger.debug(
+                        f"Ignoring low-precision position echo for local node "
+                        f"({new_precision} < {existing_precision})"
+                    )
+            else:
+                node["position"] = p
 
 
 def _onNodeInfoReceive(iface, asDict):


### PR DESCRIPTION
## Summary

- `_onPositionReceive()` now checks `precisionBits` before updating the **local node's** position
- Prevents low-precision map report echoes from overwriting the local GPS position
- Remote node positions are still updated normally (any broadcast from them reflects their current state)

## Problem

When other nodes relay our position via map reports at reduced precision (e.g., `precisionBits: 13`), the library blindly overwrites our locally-stored high-precision GPS position (`precisionBits: 32`). This causes:

- Local node position jumping to a nearby but incorrect location
- Multiple nodes appearing at the same truncated coordinates
- Position accuracy degrading from ~1m to ~1km after 10-15 seconds of mesh traffic

This only affects the **local node** — since we have the GPS internally, any lower-precision update is always an echo from the mesh, never fresh data. Remote nodes legitimately send their own positions at whatever precision their GPS provides, so those updates should always be accepted.

## Fix

Added a check in `_onPositionReceive()` that detects if the position update is for the local node (by comparing `asDict["from"]` to `iface.myInfo.my_node_num`). For the local node only, it compares `precisionBits` and rejects updates with lower precision. Remote node positions continue to be updated unconditionally.

## Test plan

- [ ] Connect to a Meshtastic device with GPS via the Python library
- [ ] Read local node position immediately after connection (should be high precision, e.g., 32 bits)
- [ ] Wait for mesh traffic with low-precision map report echoes
- [ ] Verify local node position is NOT overwritten by lower-precision echo
- [ ] Verify remote node positions ARE still updated normally (including lower-precision updates)

Fixes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)