### PR TITLE
Pin protobuf to <5 for Meshtastic 2.7.8 compatibility (fix factoryReset TypeError)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.9,<3.15"                                               # 3.9 is needed for pandas
 pyserial = "^3.5"
-protobuf = ">=4.21.12"
+protobuf = ">=4.21.12,<5"
 tabulate = "^0.9.0"
 requests = "^2.31.0"
 pyyaml = "^6.0.1"


### PR DESCRIPTION
This PR adds an upper bound for protobuf to prevent runtime breakage observed with newer protobuf major versions.

Problem
Using Meshtastic CLI 2.7.8 with protobuf 7.x causes a runtime error in factoryReset paths:

TypeError: Cannot set meshtastic.protobuf.AdminMessage.factory_reset_config to True
Field expects int, but a bool is rejected by newer protobuf type checking behavior.
This can be reproduced on Python 3.11 after dependency resolution installs protobuf 7.x (for some reason).

Root cause
meshtastic 2.7.8 currently allows protobuf versions that are too new for its generated protobuf/message assignment behavior in this code path.
With protobuf 7.x, setter validation is stricter and fails where 4.x still works.

Change in this PR
Constrain protobuf dependency to a compatible range:
protobuf>=4.21.12,<5