### PR TITLE
Handle ROUTING_APP error response in onResponseTraceRoute

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -689,7 +689,8 @@ class MeshInterface:  # pylint: disable=R0902
         """on response for trace route"""
         if p["decoded"]["portnum"] == "ROUTING_APP":
             error = p["decoded"]["routing"]["errorReason"]
-            print(f"Traceroute failed: {error}")
+            if error != "NONE":
+                print(f"Traceroute failed: {error}")
             self._acknowledgment.receivedTraceRoute = True
             return
 

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -687,6 +687,12 @@ class MeshInterface:  # pylint: disable=R0902
 
     def onResponseTraceRoute(self, p: dict):
         """on response for trace route"""
+        if p["decoded"]["portnum"] == "ROUTING_APP":
+            error = p["decoded"]["routing"]["errorReason"]
+            print(f"Traceroute failed: {error}")
+            self._acknowledgment.receivedTraceRoute = True
+            return
+
         UNK_SNR = -128 # Value representing unknown SNR
 
         routeDiscovery = mesh_pb2.RouteDiscovery()

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -757,3 +757,23 @@ def test_timeago_fuzz(seconds):
     """Fuzz _timeago to ensure it works with any integer"""
     val = _timeago(seconds)
     assert re.match(r"(now|\d+ (secs?|mins?|hours?|days?|months?|years?))", val)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_onResponseTraceRoute_routing_error(capsys):
+    """Test that onResponseTraceRoute handles ROUTING_APP error packets correctly."""
+    iface = MeshInterface(noProto=True)
+
+    packet = {
+        "decoded": {
+            "portnum": "ROUTING_APP",
+            "routing": {"errorReason": "MAX_RETRANSMIT"},
+        }
+    }
+
+    iface.onResponseTraceRoute(packet)
+
+    assert iface._acknowledgment.receivedTraceRoute is True
+    out, _ = capsys.readouterr()
+    assert "Traceroute failed: MAX_RETRANSMIT" in out

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -777,3 +777,23 @@ def test_onResponseTraceRoute_routing_error(capsys):
     assert iface._acknowledgment.receivedTraceRoute is True
     out, _ = capsys.readouterr()
     assert "Traceroute failed: MAX_RETRANSMIT" in out
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_onResponseTraceRoute_routing_none(capsys):
+    """Test that onResponseTraceRoute does not print error for ROUTING_APP with NONE errorReason."""
+    iface = MeshInterface(noProto=True)
+
+    packet = {
+        "decoded": {
+            "portnum": "ROUTING_APP",
+            "routing": {"errorReason": "NONE"},
+        }
+    }
+
+    iface.onResponseTraceRoute(packet)
+
+    assert iface._acknowledgment.receivedTraceRoute is True
+    out, _ = capsys.readouterr()
+    assert "Traceroute failed" not in out


### PR DESCRIPTION
## Summary

- `onResponseTraceRoute` did not handle `ROUTING_APP` error packets, causing it to attempt parsing them as `RouteDiscovery` payloads, resulting in a crash or silent failure followed by a spurious timeout message
- Added a check at the start of `onResponseTraceRoute` that prints the specific `errorReason` and exits the wait loop cleanly
- Unlike `onResponseTelemetry` and `onResponseWaypoint` which show a hardcoded firmware version message, traceroute shows the actual error reason since it is a diagnostic tool where knowing the specific failure is more valuable

## Test plan

- [ ] Traceroute to unreachable node shows `Traceroute failed: MAX_RETRANSMIT` (or relevant error) without a spurious `Timed out waiting for traceroute` message
- [ ] Successful traceroute still displays route correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)