### PR TITLE
Initial implementation of simradio-based testing with a multi-node simulated mesh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           poetry install
           poetry run meshtastic --version
 
-  firmware:
+  simradio_testing:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,14 @@ jobs:
 
   simradio_testing:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        channel:
+          - beta
+          - alpha
+          - daily
+    continue-on-error: ${{ matrix.channel == 'daily' }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Python 3
@@ -85,9 +93,9 @@ jobs:
           pip3 install poetry
           poetry install --all-extras --with dev
           poetry run meshtastic --version
-      - name: Install meshtasticd (beta) from PPA
+      - name: Install meshtasticd (${{ matrix.channel }}) from PPA
         run: |
-          sudo add-apt-repository -y ppa:meshtastic/beta
+          sudo add-apt-repository -y ppa:meshtastic/${{ matrix.channel }}
           sudo apt-get update
           sudo apt-get install -y meshtasticd
       - name: Run firmware smoke tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
+          - "3.14"
     steps:
       - uses: actions/checkout@v4
       - name: Install Python 3
@@ -56,12 +58,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
-          - "3.10"
-          - "3.11"
           - "3.12"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install Python 3
         uses: actions/setup-python@v5
       - name: Install meshtastic from local
@@ -83,6 +84,8 @@ jobs:
     continue-on-error: ${{ matrix.channel == 'daily' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install Python 3
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,26 @@ jobs:
           pip3 install poetry
           poetry install
           poetry run meshtastic --version
+
+  firmware:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install meshtastic from local
+        run: |
+          python -m pip install --upgrade pip
+          pip3 install poetry
+          poetry install --all-extras --with dev
+          poetry run meshtastic --version
+      - name: Install meshtasticd (beta) from PPA
+        run: |
+          sudo add-apt-repository -y ppa:meshtastic/beta
+          sudo apt-get update
+          sudo apt-get install -y meshtasticd
+      - name: Run firmware smoke tests
+        run: poetry run pytest -m "smokevirt or smokemesh" -v
+        timeout-minutes: 15

--- a/.github/workflows/daily_simradio.yml
+++ b/.github/workflows/daily_simradio.yml
@@ -1,0 +1,36 @@
+name: Daily SimRadio Tests
+
+on:
+  schedule:
+    - cron: 0 6 * * *
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  simradio_testing:
+    runs-on: ubuntu-latest
+    if: github.repository == 'meshtastic/meshtastic-python'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install meshtastic from local
+        run: |
+          python -m pip install --upgrade pip
+          pip3 install poetry
+          poetry install --all-extras --with dev
+          poetry run meshtastic --version
+      - name: Install meshtasticd (daily) from PPA
+        run: |
+          sudo add-apt-repository -y ppa:meshtastic/daily
+          sudo apt-get update
+          sudo apt-get install -y meshtasticd
+      - name: Run firmware smoke tests
+        run: poetry run pytest -m "smokevirt or smokemesh" -v
+        timeout-minutes: 15

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -970,13 +970,13 @@ def onConnected(interface):
             setSimpleConfig(config_pb2.Config.LoRaConfig.ModemPreset.LONG_SLOW)
 
         if args.ch_longmod:
-            setSimpleConfig(config_pb2.config.LoRaConfig.ModemPreset.LONG_MODERATE)
+            setSimpleConfig(config_pb2.Config.LoRaConfig.ModemPreset.LONG_MODERATE)
 
         if args.ch_longfast:
             setSimpleConfig(config_pb2.Config.LoRaConfig.ModemPreset.LONG_FAST)
 
         if args.ch_longturbo:
-            setSimpleConfig(config_pb2.config.LoRaConfig.ModemPreset.LONG_TURBO)
+            setSimpleConfig(config_pb2.Config.LoRaConfig.ModemPreset.LONG_TURBO)
 
         if args.ch_medslow:
             setSimpleConfig(config_pb2.Config.LoRaConfig.ModemPreset.MEDIUM_SLOW)
@@ -991,7 +991,7 @@ def onConnected(interface):
             setSimpleConfig(config_pb2.Config.LoRaConfig.ModemPreset.SHORT_FAST)
 
         if args.ch_shortturbo:
-            setSimpleConfig(config_pb2.config.LoRaConfig.ModemPreset.SHORT_TURBO)
+            setSimpleConfig(config_pb2.Config.LoRaConfig.ModemPreset.SHORT_TURBO)
 
         if args.ch_set or args.ch_enable or args.ch_disable:
             closeNow = True
@@ -1969,7 +1969,7 @@ def addConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
 
     group.add_argument(
         "--ch-vlongslow",
-        help="Change to the VERY_LONG_SLOW modem preset. Deprecated sincce 2.5 firmware.",
+        help="Change to the VERY_LONG_SLOW modem preset. Deprecated since 2.5 firmware.",
         action="store_true",
     )
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -969,8 +969,14 @@ def onConnected(interface):
         if args.ch_longslow:
             setSimpleConfig(config_pb2.Config.LoRaConfig.ModemPreset.LONG_SLOW)
 
+        if args.ch_longmod:
+            setSimpleConfig(config_pb2.config.LoRaConfig.ModemPreset.LONG_MODERATE)
+
         if args.ch_longfast:
             setSimpleConfig(config_pb2.Config.LoRaConfig.ModemPreset.LONG_FAST)
+
+        if args.ch_longturbo:
+            setSimpleConfig(config_pb2.config.LoRaConfig.ModemPreset.LONG_TURBO)
 
         if args.ch_medslow:
             setSimpleConfig(config_pb2.Config.LoRaConfig.ModemPreset.MEDIUM_SLOW)
@@ -983,6 +989,9 @@ def onConnected(interface):
 
         if args.ch_shortfast:
             setSimpleConfig(config_pb2.Config.LoRaConfig.ModemPreset.SHORT_FAST)
+
+        if args.ch_shortturbo:
+            setSimpleConfig(config_pb2.config.LoRaConfig.ModemPreset.SHORT_TURBO)
 
         if args.ch_set or args.ch_enable or args.ch_disable:
             closeNow = True
@@ -1960,43 +1969,61 @@ def addConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
 
     group.add_argument(
         "--ch-vlongslow",
-        help="Change to the very long-range and slow modem preset",
+        help="Change to the VERY_LONG_SLOW modem preset. Deprecated sincce 2.5 firmware.",
         action="store_true",
     )
 
     group.add_argument(
         "--ch-longslow",
-        help="Change to the long-range and slow modem preset",
+        help="Change to the LONG_SLOW modem preset. Deprecated since 2.7 firmware.",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--ch-longmod", "--ch-longmoderate",
+        help="Change to the LONG_MODERATE modem preset",
         action="store_true",
     )
 
     group.add_argument(
         "--ch-longfast",
-        help="Change to the long-range and fast modem preset",
+        help="Change to the LONG_FAST modem preset",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--ch-longturbo",
+        help="Change to the LONG_TURBO preset",
         action="store_true",
     )
 
     group.add_argument(
         "--ch-medslow",
-        help="Change to the med-range and slow modem preset",
+        help="Change to the MEDIUM_SLOW modem preset",
         action="store_true",
     )
 
     group.add_argument(
         "--ch-medfast",
-        help="Change to the med-range and fast modem preset",
+        help="Change to the MEDIUM_FAST modem preset",
         action="store_true",
     )
 
     group.add_argument(
         "--ch-shortslow",
-        help="Change to the short-range and slow modem preset",
+        help="Change to the SHORT_SLOW modem preset",
         action="store_true",
     )
 
     group.add_argument(
         "--ch-shortfast",
-        help="Change to the short-range and fast modem preset",
+        help="Change to the SHORT_FAST modem preset",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--ch-shortturbo",
+        help="Change to the SHORT_TURBO modem preset",
         action="store_true",
     )
 

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -287,12 +287,22 @@ class Node:
         # for sending admin channels will also change
         adminIndex = self.iface.localNode._getAdminChannelIndex()
 
+        # Snapshot serialized channel payloads from channelIndex onward so we
+        # can avoid writing slots whose protobuf content did not change after
+        # the shift. Use bytes (not message objects), because _fixupChannels()
+        # mutates message fields in-place.
+        old_channels = [
+            self.channels[i].SerializeToString()
+            for i in range(channelIndex, len(self.channels))
+        ]
+
         self.channels.pop(channelIndex)
         self._fixupChannels()  # expand back to 8 channels
 
         index = channelIndex
-        while index < 8:
-            self.writeChannel(index, adminIndex=adminIndex)
+        for old_ch in old_channels:
+            if self.channels[index].SerializeToString() != old_ch:
+                self.writeChannel(index, adminIndex=adminIndex)
             index += 1
 
             # if we are updating the local node, we might end up

--- a/meshtastic/tests/conftest.py
+++ b/meshtastic/tests/conftest.py
@@ -8,6 +8,56 @@ import pytest
 from meshtastic import mt_config
 
 from ..mesh_interface import MeshInterface
+from .firmware_harness import (
+    CHAIN_TOPOLOGY,
+    DEFAULT_BASE_PORT,
+    SimMesh,
+    find_meshtasticd,
+    is_compatible_host,
+)
+
+# Use a different base port for the single-node fixture so it doesn't
+# conflict with the multi-node mesh fixture (both are session-scoped).
+SINGLE_NODE_BASE_PORT = DEFAULT_BASE_PORT + 100
+
+
+def _skip_firmware_if_unavailable() -> None:
+    """Skip the test when meshtasticd can't run on this host."""
+    if not is_compatible_host():
+        pytest.skip("meshtasticd firmware tests require Linux")
+    if find_meshtasticd() is None:
+        pytest.skip(
+            "meshtasticd not found — set MESHTASTICD_BIN or install it on PATH"
+        )
+
+
+@pytest.fixture(scope="session")
+def firmware_node():
+    """A single meshtasticd sim node for smokevirt tests.
+
+    Yields the SimNode instance.  The node is booted with a fresh erased
+    config and listens on localhost at its TCP port.
+    """
+    _skip_firmware_if_unavailable()
+    mesh = SimMesh(n_nodes=1, base_port=SINGLE_NODE_BASE_PORT)
+    mesh.start()
+    yield mesh.get_node(0)
+    mesh.stop()
+
+
+@pytest.fixture(scope="function")
+def firmware_mesh():
+    """A 3-node chain (A-B-C) meshtasticd sim mesh for smokemesh tests.
+
+    Yields the SimMesh instance.  Nodes are connected and the SIMULATOR_APP
+    packet bridge is running.  Node DB convergence is awaited.
+    """
+    _skip_firmware_if_unavailable()
+    mesh = SimMesh(n_nodes=3, topology=CHAIN_TOPOLOGY)
+    mesh.start()
+    mesh.wait_for_convergence(timeout=30)
+    yield mesh
+    mesh.stop()
 
 
 @pytest.fixture

--- a/meshtastic/tests/conftest.py
+++ b/meshtastic/tests/conftest.py
@@ -15,6 +15,7 @@ from .firmware_harness import (
     find_meshtasticd,
     is_compatible_host,
 )
+from .fw_helpers import set_region
 
 # Use a different base port for the single-node fixture so it doesn't
 # conflict with the multi-node mesh fixture.
@@ -41,11 +42,14 @@ def firmware_node():
     tests be order-independent.
 
     Yields the SimNode instance.  The node is booted with a fresh erased
-    config and listens on localhost at its TCP port.
+    config and listens on localhost at its TCP port.  Region is set to US
+    so modem-preset tests work against firmware >= 2.8, which clamps
+    presets to the legal set for the current region.
     """
     _skip_firmware_if_unavailable()
     mesh = SimMesh(n_nodes=1, base_port=SINGLE_NODE_BASE_PORT)
     mesh.start()
+    set_region(mesh.get_node(0).port, "US")
     yield mesh.get_node(0)
     mesh.stop()
 
@@ -55,11 +59,24 @@ def firmware_mesh():
     """A 3-node chain (A-B-C) meshtasticd sim mesh for smokemesh tests.
 
     Yields the SimMesh instance.  Nodes are connected and the SIMULATOR_APP
-    packet bridge is running.  Node DB convergence is awaited.
+    packet bridge is running.  Region is set to US for firmware >= 2.8
+    compatibility, interfaces are reconnected after the region change, and
+    node DB convergence is awaited.
     """
     _skip_firmware_if_unavailable()
     mesh = SimMesh(n_nodes=3, topology=CHAIN_TOPOLOGY)
     mesh.start()
+    for node in mesh.nodes:
+        set_region(node.port, "US")
+    # The region commit restarts each node's TCP listener, so reconnect the
+    # harness interfaces before waiting for convergence.
+    for node in mesh.nodes:
+        if node.iface is not None:
+            try:
+                node.iface.close()
+            except Exception:  # pylint: disable=broad-except
+                pass
+        node.connect()
     mesh.wait_for_convergence(timeout=30)
     yield mesh
     mesh.stop()

--- a/meshtastic/tests/conftest.py
+++ b/meshtastic/tests/conftest.py
@@ -17,7 +17,7 @@ from .firmware_harness import (
 )
 
 # Use a different base port for the single-node fixture so it doesn't
-# conflict with the multi-node mesh fixture (both are session-scoped).
+# conflict with the multi-node mesh fixture.
 SINGLE_NODE_BASE_PORT = DEFAULT_BASE_PORT + 100
 
 
@@ -31,9 +31,14 @@ def _skip_firmware_if_unavailable() -> None:
         )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def firmware_node():
     """A single meshtasticd sim node for smokevirt tests.
+
+    Function-scoped so every test gets a freshly-erased node with no
+    state leaking from previous tests. This makes destructive commands
+    (``--reboot``, ``--set factory_reset true``) safe to run and lets
+    tests be order-independent.
 
     Yields the SimNode instance.  The node is booted with a fresh erased
     config and listens on localhost at its TCP port.

--- a/meshtastic/tests/conftest.py
+++ b/meshtastic/tests/conftest.py
@@ -49,8 +49,17 @@ def firmware_node():
     _skip_firmware_if_unavailable()
     mesh = SimMesh(n_nodes=1, base_port=SINGLE_NODE_BASE_PORT)
     mesh.start()
-    set_region(mesh.get_node(0).port, "US")
-    yield mesh.get_node(0)
+    node = mesh.get_node(0)
+    set_region(node.port, "US")
+    # The region commit restarts the TCP listener, so reconnect the harness
+    # interface in case a test wants to use it directly.
+    if node.iface is not None:
+        try:
+            node.iface.close()
+        except Exception:  # pylint: disable=broad-except
+            pass
+    node.connect()
+    yield node
     mesh.stop()
 
 

--- a/meshtastic/tests/firmware_harness.py
+++ b/meshtastic/tests/firmware_harness.py
@@ -161,6 +161,9 @@ class SimNode:
                     os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
                 except Exception:
                     pass
+            # Give OS time to release TCP port (avoid TIME_WAIT preventing
+            # next instance from binding the same port)
+            time.sleep(1.0)
             self.process = None
 
 

--- a/meshtastic/tests/firmware_harness.py
+++ b/meshtastic/tests/firmware_harness.py
@@ -1,0 +1,345 @@
+"""Test harness for running real meshtasticd firmware instances.
+
+Launches one or more meshtasticd processes in simulator mode (-s) and bridges
+their "over-the-air" packets via the SIMULATOR_APP protocol so that multiple
+instances can communicate as if via LoRa, with a configurable topology.
+
+The harness expects meshtasticd to be available on PATH or via the
+MESHTASTICD_BIN environment variable.  It does not download or build the
+binary itself.
+"""
+import logging
+import os
+import platform
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+from typing import Dict, List, Optional, Set
+
+from pubsub import pub  # type: ignore[import-untyped]
+
+from meshtastic import BROADCAST_NUM, mesh_pb2, portnums_pb2
+from meshtastic.tcp_interface import TCPInterface
+
+logger = logging.getLogger(__name__)
+
+HW_ID_OFFSET = 16
+DEFAULT_BASE_PORT = 4404
+DEFAULT_RSSI = -50
+DEFAULT_SNR = 10.0
+BOOT_TIMEOUT = 30
+CONNECT_TIMEOUT = 30
+
+CHAIN_TOPOLOGY: Dict[int, Set[int]] = {
+    0: {1},
+    1: {0, 2},
+    2: {1},
+}
+
+
+def find_meshtasticd() -> Optional[str]:
+    """Return the path to the meshtasticd binary, or None if not found."""
+    env_path = os.environ.get("MESHTASTICD_BIN")
+    if env_path and os.path.isfile(env_path) and os.access(env_path, os.X_OK):
+        return env_path
+    return shutil.which("meshtasticd")
+
+
+def is_compatible_host() -> bool:
+    """True when the host can run meshtasticd natively (Linux only)."""
+    return platform.system() == "Linux"
+
+
+def _wait_for_port(port: int, timeout: int = BOOT_TIMEOUT) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            s = socket.create_connection(("localhost", port), timeout=0.5)
+            s.close()
+            return True
+        except OSError:
+            time.sleep(0.5)
+    return False
+
+
+class SimNode:
+    """A single meshtasticd simulator instance."""
+
+    def __init__(self, node_id: int, base_port: int = DEFAULT_BASE_PORT):
+        self.node_id = node_id
+        self.hw_id = node_id + HW_ID_OFFSET
+        self.port = base_port + node_id
+        self.process: Optional[subprocess.Popen] = None
+        self.workdir: Optional[str] = None
+        self.iface: Optional[TCPInterface] = None
+        self._log_files: list = []
+
+    @property
+    def node_num(self) -> int:
+        """The firmware-assigned node number (== hw_id)."""
+        if self.iface and self.iface.myInfo:
+            return self.iface.myInfo.my_node_num
+        return self.hw_id
+
+    def start(self, binary: str) -> None:
+        """Launch the meshtasticd process in simulator mode."""
+        self.workdir = tempfile.mkdtemp(prefix=f"mtd_node{self.node_id}_")
+        vfs_dir = os.path.join(self.workdir, "vfs")
+        os.mkdir(vfs_dir)
+        log_stdout = open(os.path.join(self.workdir, "meshtasticd.log"), "wb", buffering=0)
+        log_stderr = open(os.path.join(self.workdir, "meshtasticd.err"), "wb", buffering=0)
+        self._log_files = [log_stdout, log_stderr]
+        self.process = subprocess.Popen(  # pylint: disable=consider-using-with
+            [
+                binary,
+                "-s",
+                "-h", str(self.hw_id),
+                "-p", str(self.port),
+                "-d", vfs_dir,
+                "-e",
+            ],
+            stdout=log_stdout,
+            stderr=log_stderr,
+            start_new_session=True,
+        )
+        if not _wait_for_port(self.port):
+            self._kill()
+            raise RuntimeError(
+                f"meshtasticd node {self.node_id} did not start listening on port {self.port}"
+            )
+    def connect(self) -> None:
+        """Open a TCPInterface connection to this node."""
+        self.iface = TCPInterface(
+            hostname="localhost",
+            portNumber=self.port,
+            connectNow=False,
+        )
+        self.iface.myConnect()
+        self.iface.connect()
+
+    def close(self) -> None:
+        """Close the interface and kill the process."""
+        if self.iface is not None:
+            try:
+                self.iface.localNode.exitSimulator()
+            except Exception:
+                pass
+            try:
+                self.iface.close()
+            except Exception:
+                pass
+            self.iface = None
+        self._kill()
+        if self.workdir:
+            shutil.rmtree(self.workdir, ignore_errors=True)
+            self.workdir = None
+
+    def _kill(self) -> None:
+        for f in self._log_files:
+            try:
+                f.close()
+            except Exception:
+                pass
+        self._log_files = []
+        if self.process is not None:
+            try:
+                os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
+            except (ProcessLookupError, OSError):
+                pass
+            try:
+                self.process.wait(timeout=5)
+            except Exception:
+                try:
+                    os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
+                except Exception:
+                    pass
+            self.process = None
+
+
+class SimMesh:
+    """Manages N meshtasticd sim instances and bridges their SIMULATOR_APP packets.
+
+    When *topology* is None every node hears every other node (full mesh).
+    Otherwise *topology* maps a transmitter's node index to the set of receiver
+    node indices that can hear it.
+    """
+
+    def __init__(
+        self,
+        n_nodes: int = 1,
+        topology: Optional[Dict[int, Set[int]]] = None,
+        base_port: int = DEFAULT_BASE_PORT,
+    ):
+        self.n_nodes = n_nodes
+        self.topology = topology
+        self.base_port = base_port
+        self.nodes: List[SimNode] = [
+            SimNode(i, base_port) for i in range(n_nodes)
+        ]
+        self._port_to_idx: Dict[int, int] = {}
+        self._started = False
+
+    def start(self) -> None:
+        """Launch all nodes, connect, and start the packet bridge."""
+        binary = find_meshtasticd()
+        if binary is None:
+            raise RuntimeError(
+                "meshtasticd not found. Set MESHTASTICD_BIN or install it on PATH."
+            )
+
+        for node in self.nodes:
+            node.start(binary)
+
+        for node in self.nodes:
+            node.connect()
+            self._port_to_idx[node.port] = node.node_id
+
+        pub.subscribe(self._on_sim_packet, "meshtastic.receive.simulator")
+        self._started = True
+
+        if self.n_nodes > 1:
+            self._trigger_convergence()
+
+    def _trigger_convergence(self) -> None:
+        """Actively trigger NodeInfo exchange instead of waiting passively.
+
+        Sends a NODEINFO_APP packet with wantResponse from each node so the
+        firmware's NodeInfoModule responds with its own user info, populating
+        all node DBs deterministically.
+        """
+        for node in self.nodes:
+            iface = node.iface
+            if iface is None:
+                continue
+            user = mesh_pb2.User()
+            user.id = f"!{node.node_num:08x}"
+            user.long_name = f"Node {node.node_id}"
+            user.short_name = f"{node.node_id:04d}"[:4]
+            user.hw_model = mesh_pb2.HardwareModel.PORTDUINO
+            try:
+                iface.sendData(
+                    user,
+                    destinationId=BROADCAST_NUM,
+                    portNum=portnums_pb2.PortNum.NODEINFO_APP,
+                    wantAck=False,
+                    wantResponse=True,
+                )
+            except Exception as ex:
+                logger.debug("NodeInfo trigger for node %d failed: %s", node.node_id, ex)
+        time.sleep(5)
+
+    def stop(self) -> None:
+        """Shut down all nodes and clean up."""
+        if not self._started:
+            return
+        try:
+            pub.unsubscribe(self._on_sim_packet, "meshtastic.receive.simulator")
+        except Exception:
+            pass
+        for node in self.nodes:
+            node.close()
+        self._started = False
+
+    def get_node(self, idx: int) -> SimNode:
+        return self.nodes[idx]
+
+    def get_iface(self, idx: int) -> TCPInterface:
+        iface = self.nodes[idx].iface
+        assert iface is not None, f"node {idx} has no interface"
+        return iface
+
+    def wait_for_convergence(self, timeout: int = 30) -> bool:
+        """Wait until every node sees all others in its node DB.
+
+        Returns True if converged, False if timed out (non-fatal — the packet
+        bridge forwards regardless of node DB state).
+        """
+        if self.n_nodes <= 1:
+            return True
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if all(
+                node.iface is not None
+                and node.iface.nodes is not None
+                and len(node.iface.nodes) >= self.n_nodes
+                for node in self.nodes
+            ):
+                return True
+            time.sleep(2)
+        logger.warning("Mesh did not fully converge within %ds", timeout)
+        return False
+
+    def _get_receivers(self, tx_idx: int) -> List[int]:
+        """Return node indices that can hear a transmission from *tx_idx*."""
+        if self.topology is not None:
+            return sorted(self.topology.get(tx_idx, set()))
+        return [i for i in range(self.n_nodes) if i != tx_idx]
+
+    def _on_sim_packet(self, interface, packet) -> None:
+        """Bridge callback: forward a SIMULATOR_APP packet to receiving nodes."""
+        tx_port = getattr(interface, "portNumber", None)
+        tx_idx = self._port_to_idx.get(tx_port) if tx_port else None
+        if tx_idx is None:
+            return
+
+        rx_indices = self._get_receivers(tx_idx)
+        if not rx_indices:
+            return
+
+        data = packet["decoded"]["payload"]
+        if hasattr(data, "SerializeToString"):
+            data = data.SerializeToString()
+
+        if len(data) > mesh_pb2.Constants.DATA_PAYLOAD_LEN:
+            logger.warning("Simulator payload too big (%d bytes), dropping", len(data))
+            return
+
+        mesh_packet = _build_mesh_packet(packet, data)
+
+        for rx_idx in rx_indices:
+            rx_iface = self.nodes[rx_idx].iface
+            if rx_iface is None:
+                continue
+            mesh_packet.rx_rssi = DEFAULT_RSSI
+            mesh_packet.rx_snr = DEFAULT_SNR
+            to_radio = mesh_pb2.ToRadio()
+            to_radio.packet.CopyFrom(mesh_packet)
+            try:
+                rx_iface._sendToRadio(to_radio)
+            except Exception as ex:
+                logger.error("Error forwarding packet to node %d: %s", rx_idx, ex)
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *exc):
+        self.stop()
+
+
+def _build_mesh_packet(packet: dict, data: bytes) -> mesh_pb2.MeshPacket:
+    """Reconstruct a MeshPacket for SIMULATOR_APP injection."""
+    mp = mesh_pb2.MeshPacket()
+    mp.decoded.payload = data
+    mp.decoded.portnum = portnums_pb2.PortNum.SIMULATOR_APP
+    mp.to = packet.get("to", BROADCAST_NUM)
+    setattr(mp, "from", packet.get("from", 0))
+    mp.id = packet.get("id", 0)
+    mp.want_ack = packet.get("wantAck", False)
+    mp.hop_limit = packet.get("hopLimit", 0)
+    mp.hop_start = packet.get("hopStart", 0)
+    mp.via_mqtt = packet.get("viaMQTT", False)
+    mp.relay_node = packet.get("relayNode", 0)
+    mp.next_hop = packet.get("nextHop", 0)
+    mp.channel = int(packet.get("channel", 0))
+
+    decoded = packet.get("decoded", {})
+    if "requestId" in decoded:
+        mp.decoded.request_id = decoded["requestId"]
+    if "wantResponse" in decoded:
+        mp.decoded.want_response = decoded["wantResponse"]
+
+    return mp

--- a/meshtastic/tests/firmware_harness.py
+++ b/meshtastic/tests/firmware_harness.py
@@ -89,8 +89,13 @@ class SimNode:
         self.workdir = tempfile.mkdtemp(prefix=f"mtd_node{self.node_id}_")
         vfs_dir = os.path.join(self.workdir, "vfs")
         os.mkdir(vfs_dir)
-        log_stdout = open(os.path.join(self.workdir, "meshtasticd.log"), "wb", buffering=0)
-        log_stderr = open(os.path.join(self.workdir, "meshtasticd.err"), "wb", buffering=0)
+        # Files are closed in _kill(); keep them open for the process lifetime.
+        log_stdout = open(  # pylint: disable=consider-using-with
+            os.path.join(self.workdir, "meshtasticd.log"), "wb", buffering=0
+        )
+        log_stderr = open(  # pylint: disable=consider-using-with
+            os.path.join(self.workdir, "meshtasticd.err"), "wb", buffering=0
+        )
         self._log_files = [log_stdout, log_stderr]
         self.process = subprocess.Popen(  # pylint: disable=consider-using-with
             [
@@ -244,9 +249,11 @@ class SimMesh:
         self._started = False
 
     def get_node(self, idx: int) -> SimNode:
+        """Return the SimNode at the given index."""
         return self.nodes[idx]
 
     def get_iface(self, idx: int) -> TCPInterface:
+        """Return the TCPInterface for the node at the given index."""
         iface = self.nodes[idx].iface
         assert iface is not None, f"node {idx} has no interface"
         return iface

--- a/meshtastic/tests/fw_helpers.py
+++ b/meshtastic/tests/fw_helpers.py
@@ -31,6 +31,11 @@ logger = logging.getLogger(__name__)
 # simulator happy when many short-lived connections are happening.
 PAUSE_AFTER_CLI = 0.2
 
+# Pause after changing the LoRa region. The firmware may restart the TCP
+# listener while committing the new radio config, so give it time to settle
+# before the next CLI call or harness reconnect.
+PAUSE_AFTER_REGION_CHANGE = 2.0
+
 
 # ---------------------------------------------------------------------------
 # CLI invocation
@@ -325,6 +330,19 @@ def subscribe_positions(iface: TCPInterface) -> PacketCollector:
     return _subscribe_topic(iface, "meshtastic.receive.position")
 
 
+def set_region(port: int, region: str = "US") -> None:
+    """Set the LoRa region on a sim node via the CLI.
+
+    The node briefly restarts its TCP listener while committing the radio
+    config; ``run_cli()`` handles the reconnect retry, and we sleep long
+    enough for the new region to take effect before callers continue.
+    """
+    rc, out = run_cli(port, "--set", "lora.region", region)
+    if rc != 0:
+        raise RuntimeError(f"Failed to set lora.region={region}: {out}")
+    time.sleep(PAUSE_AFTER_REGION_CHANGE)
+
+
 def unsubscribe_all(topic: str) -> None:
     """Drop every handler currently registered on *topic*.
 
@@ -339,12 +357,14 @@ def unsubscribe_all(topic: str) -> None:
 
 __all__ = [
     "PAUSE_AFTER_CLI",
+    "PAUSE_AFTER_REGION_CHANGE",
     "PacketCollector",
     "RECEIVE_TIMEOUT",
     "cli_then_verify",
     "connect_iface",
     "resolve_cli",
     "run_cli",
+    "set_region",
     "subscribe_positions",
     "subscribe_telemetries",
     "subscribe_texts",

--- a/meshtastic/tests/fw_helpers.py
+++ b/meshtastic/tests/fw_helpers.py
@@ -1,0 +1,354 @@
+"""Shared helpers for meshtasticd-backed smoke tests.
+
+Both ``test_smokevirt`` (single node) and ``test_smokemesh`` (multi-node
+chain) use these helpers to drive the ``meshtastic`` CLI against real
+``meshtasticd`` simulator instances and then verify the resulting firmware
+state through the Python library's ``TCPInterface``.
+
+Verifying through the library (rather than regex on CLI stdout) is the
+core design choice: it makes tests robust against CLI wording changes
+while still exercising both the CLI argparse path and the firmware I/O
+path of every feature.
+"""
+from __future__ import annotations
+
+import logging
+import shlex
+import socket
+import subprocess
+import sys
+import time
+from typing import Callable, List, Optional, Tuple
+
+from pubsub import pub  # type: ignore[import-untyped]
+
+from meshtastic.tcp_interface import TCPInterface
+
+logger = logging.getLogger(__name__)
+
+# Pause between a CLI command finishing and a verification interface
+# opening, to let the firmware flush its TCP bookkeeping. Keeps the
+# simulator happy when many short-lived connections are happening.
+PAUSE_AFTER_CLI = 0.2
+
+
+# ---------------------------------------------------------------------------
+# CLI invocation
+# ---------------------------------------------------------------------------
+
+def resolve_cli() -> str:
+    """Return a shell-invokable ``meshtastic`` command.
+
+    Prefers the in-tree module run through the current interpreter so
+    tests exercise the source we are editing, regardless of any
+    separately-installed ``meshtastic`` entry point on PATH.
+    """
+    # The PATH binary may live outside the nono sandbox's allowed paths;
+    # ``python -m meshtastic`` is more portable and always available.
+    return f"{sys.executable} -m meshtastic"
+
+
+def run_cli(
+    port: int,
+    *args: str,
+    timeout: int = 60,
+    retries: int = 2,
+    retry_delay: float = 1.0,
+) -> Tuple[int, str]:
+    """Run the ``meshtastic`` CLI against the sim node on *port*.
+
+    Returns ``(return_code, merged_stdout_stderr)``. ``--host
+    localhost:PORT`` is prefixed automatically. stderr is merged into
+    stdout so callers can match warning text such as "Warning: Need to
+    specify ..." regardless of which stream it lands on.
+
+    If the CLI fails to connect on the first attempt (which happens
+    transiently when a freshly-booted sim node needs a moment to settle
+    after the harness interface connects), retry up to *retries*
+    additional times after *retry_delay* seconds.
+    """
+    cli = resolve_cli()
+    argv = [*_shlex_split(cli)]
+    argv.extend(["--host", f"localhost:{port}"])
+    argv.extend(args)
+    logger.debug("run_cli: %s", argv)
+
+    last_out = ""
+    for attempt in range(retries + 1):
+        try:
+            proc = subprocess.run(
+                argv,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as ex:
+            last_out = ex.stdout.decode("utf-8", errors="replace") if ex.stdout else ""
+            if attempt < retries:
+                time.sleep(retry_delay)
+                continue
+            return 124, last_out
+
+        out = proc.stdout.decode("utf-8", errors="replace")
+        rc = proc.returncode
+
+        # Retry on transient connection-refused / timed-out errors that
+        # are common right after a sim node spins up.
+        transient = (
+            "Error connecting" in out
+            or "Timed out waiting for connection" in out
+            or "Connection reset by peer" in out
+        )
+        if rc != 0 and transient and attempt < retries:
+            logger.debug("run_cli: transient failure, retry %d/%d", attempt + 1, retries)
+            time.sleep(retry_delay)
+            last_out = out
+            continue
+        return rc, out
+    return rc, last_out
+
+
+def _shlex_split(cmd: str) -> List[str]:
+    """Split a shell string into argv, honoring quotes."""
+    return shlex.split(cmd)
+
+
+# ---------------------------------------------------------------------------
+# Fresh-connection state verification
+# ---------------------------------------------------------------------------
+
+def _wait_for_port(port: int, timeout: float = 30.0) -> None:
+    """Wait until *port* accepts a TCP connection (firmware sim comes up
+    or comes back after a config-commit reboot)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            s = socket.create_connection(("localhost", port), timeout=0.5)
+            s.close()
+            return
+        except OSError:
+            time.sleep(0.2)
+    raise TimeoutError(
+        f"port {port} did not accept connections within {timeout}s"
+    )
+
+
+def connect_iface(
+    port: int,
+    no_nodes: bool = False,
+    retries: int = 4,
+    wait_timeout: float = 30.0,
+) -> TCPInterface:
+    """Open a fresh ``TCPInterface`` to *port* and block on the config exchange.
+
+    Firmware config writes (``writeChannel``, ``--seturl``, ``--factory_reset``)
+    can briefly restart the sim's TCP listener. We wait for the port to
+    come up first, then retry the connect+config-exchange a few times.
+    """
+    last_exc: Optional[Exception] = None
+    for attempt in range(retries + 1):
+        try:
+            _wait_for_port(port, timeout=wait_timeout)
+            return TCPInterface(
+                hostname="localhost",
+                portNumber=port,
+                connectNow=True,
+                noNodes=no_nodes,
+            )
+        except Exception as ex:  # pylint: disable=broad-except
+            last_exc = ex
+            if attempt < retries:
+                logger.debug(
+                    "connect_iface attempt %d/%d failed: %s",
+                    attempt + 1, retries, ex,
+                )
+                time.sleep(0.5)
+                continue
+            raise
+    assert last_exc is not None  # type guard; unreachable
+    raise last_exc  # pragma: no cover
+
+
+def verify_state(
+    port: int,
+    verifier: Callable[[TCPInterface], None],
+    *,
+    no_nodes: bool = False,
+) -> None:
+    """Open a fresh interface and run *verifier(iface)*, then close.
+
+    Used after a CLI mutation to verify firmware state through the
+    library. Always closes the interface so the next test starts clean.
+    """
+    iface = connect_iface(port, no_nodes=no_nodes)
+    try:
+        verifier(iface)
+    finally:
+        try:
+            iface.close()
+        except Exception:  # pylint: disable=broad-except
+            pass
+        time.sleep(PAUSE_AFTER_CLI)
+
+
+def cli_then_verify(
+    port: int,
+    cli_args: List[str],
+    verifier: Optional[Callable[[TCPInterface], None]],
+    *,
+    expect_rc: Optional[int] = 0,
+    no_nodes: bool = False,
+    cli_timeout: int = 60,
+) -> str:
+    """Run *cli_args* against *port*, optionally asserting *expect_rc*,
+    then (if *verifier* is not None) open a fresh interface and run
+    *verifier(iface)* against the just-mutated firmware state.
+
+    Returns the CLI stdout.
+    """
+    rc, out = run_cli(port, *cli_args, timeout=cli_timeout)
+    if expect_rc is not None:
+        assert rc == expect_rc, f"CLI rc={rc} (expected {expect_rc}): {out}"
+    time.sleep(PAUSE_AFTER_CLI)
+    if verifier is not None:
+        verify_state(port, verifier, no_nodes=no_nodes)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Packet collectors (used by smokemesh receive-verification tests)
+# ---------------------------------------------------------------------------
+
+RECEIVE_TIMEOUT = 15.0
+
+
+class PacketCollector:
+    """Collect packets received on a specific interface via pubsub.
+
+    ``Listener`` (pubsub 4.x) wraps handlers with a weak reference, so
+    we keep a strong reference to ``handler`` on the instance to prevent
+    garbage collection before the publishing thread gets to call it.
+    """
+
+    def __init__(self):
+        self.packets: List[dict] = []
+        self._handler: Optional[Callable] = None
+
+    def on_receive(self, packet, interface):  # pylint: disable=unused-argument
+        """Append a received packet to the internal list."""
+        self.packets.append(packet)
+
+    def wait_for(self, count: int, timeout: float = RECEIVE_TIMEOUT) -> bool:
+        """Wait until *count* packets have been collected or *timeout* expires."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if len(self.packets) >= count:
+                return True
+            time.sleep(0.2)
+        return len(self.packets) >= count
+
+    @property
+    def texts(self) -> List[str]:
+        """Return text payloads from TEXT_MESSAGE_APP packets."""
+        return [
+            p.get("decoded", {}).get("text", "")
+            for p in self.packets
+            if p.get("decoded", {}).get("portnum") == "TEXT_MESSAGE_APP"
+        ]
+
+    @property
+    def traceroutes(self) -> List[dict]:
+        """Return TRACEROUTE_APP packets."""
+        return [
+            p for p in self.packets
+            if p.get("decoded", {}).get("portnum") == "TRACEROUTE_APP"
+        ]
+
+    @property
+    def telemetries(self) -> List[dict]:
+        """Return TELEMETRY_APP packets."""
+        return [
+            p for p in self.packets
+            if p.get("decoded", {}).get("portnum") == "TELEMETRY_APP"
+        ]
+
+    @property
+    def positions(self) -> List[dict]:
+        """Return POSITION_APP packets."""
+        return [
+            p for p in self.packets
+            if p.get("decoded", {}).get("portnum") == "POSITION_APP"
+        ]
+
+    def reset(self) -> None:
+        """Clear all collected packets."""
+        self.packets.clear()
+
+
+def _subscribe_topic(
+    iface: TCPInterface, topic: str
+) -> PacketCollector:
+    """Internal: subscribe a fully-qualified *topic* and return a collector.
+
+    Filters by *interface* so multi-node tests can subscribe several
+    collectors concurrently without cross-talk.
+    """
+    collector = PacketCollector()
+
+    def handler(packet, interface):
+        if interface is iface:
+            collector.on_receive(packet, interface)
+
+    pub.subscribe(handler, topic)
+    collector._handler = handler  # strong ref; see PacketCollector docstring
+    return collector
+
+
+def subscribe_texts(iface: TCPInterface) -> PacketCollector:
+    """Subscribe to ``meshtastic.receive.text`` filtered to *iface*."""
+    return _subscribe_topic(iface, "meshtastic.receive.text")
+
+
+def subscribe_traceroutes(iface: TCPInterface) -> PacketCollector:
+    """Subscribe to ``meshtastic.receive.traceroute`` filtered to *iface*."""
+    return _subscribe_topic(iface, "meshtastic.receive.traceroute")
+
+
+def subscribe_telemetries(iface: TCPInterface) -> PacketCollector:
+    """Subscribe to ``meshtastic.receive.telemetry`` filtered to *iface*."""
+    return _subscribe_topic(iface, "meshtastic.receive.telemetry")
+
+
+def subscribe_positions(iface: TCPInterface) -> PacketCollector:
+    """Subscribe to ``meshtastic.receive.position`` filtered to *iface*."""
+    return _subscribe_topic(iface, "meshtastic.receive.position")
+
+
+def unsubscribe_all(topic: str) -> None:
+    """Drop every handler currently registered on *topic*.
+
+    Tests use this in a ``finally`` block to keep pubsub clean across
+    the function-scoped mesh fixtures.
+    """
+    try:
+        pub.unsubAll(topic)
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+
+__all__ = [
+    "PAUSE_AFTER_CLI",
+    "PacketCollector",
+    "RECEIVE_TIMEOUT",
+    "cli_then_verify",
+    "connect_iface",
+    "resolve_cli",
+    "run_cli",
+    "subscribe_positions",
+    "subscribe_telemetries",
+    "subscribe_texts",
+    "subscribe_traceroutes",
+    "unsubscribe_all",
+    "verify_state",
+]

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -669,6 +669,78 @@ def test_getChannelByChannelIndex():
     assert anode.getChannelByChannelIndex(9) is None
 
 
+def _build_channels(highest_secondary_index: int):
+    """Build an 8-slot channel table with contiguous active channels.
+
+    Slot 0 is PRIMARY. Slots 1..highest_secondary_index are SECONDARY.
+    Remaining slots are DISABLED.
+    """
+    channels = []
+    for idx in range(8):
+        ch = Channel()
+        ch.index = idx
+        if idx == 0:
+            ch.role = Channel.Role.PRIMARY
+            ch.settings.name = "primary"
+        elif idx <= highest_secondary_index:
+            ch.role = Channel.Role.SECONDARY
+            ch.settings.name = f"ch{idx}"
+        else:
+            ch.role = Channel.Role.DISABLED
+        channels.append(ch)
+    return channels
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "highest_secondary_index,delete_index,expected_writes",
+    [
+        pytest.param(1, 1, [1], id="active-0-1-del-1"),
+        pytest.param(2, 1, [1, 2], id="active-0-2-del-1"),
+        pytest.param(3, 1, [1, 2, 3], id="active-0-3-del-1"),
+        pytest.param(3, 2, [2, 3], id="active-0-3-del-2"),
+    ],
+)
+def test_delete_channel_writes_only_changed_suffix(
+    highest_secondary_index, delete_index, expected_writes
+):
+    """deleteChannel should only write slots whose payload changed."""
+    iface = MagicMock()
+    anode = Node(iface, "bar", noProto=True)
+    iface.localNode = anode
+    anode.channels = _build_channels(highest_secondary_index)
+
+    writes = []
+
+    def fake_write(channel_index, adminIndex=0):
+        writes.append((channel_index, adminIndex))
+
+    anode.writeChannel = fake_write
+
+    anode.deleteChannel(delete_index)
+
+    written_indices = [idx for idx, _ in writes]
+    assert written_indices == expected_writes
+    assert all(admin_idx == 0 for _, admin_idx in writes)
+    assert 0 not in written_indices
+    assert all(idx < 4 for idx in written_indices)
+
+
+@pytest.mark.unit
+def test_delete_channel_rejects_primary():
+    """deleteChannel should refuse deleting PRIMARY slot 0."""
+    iface = MagicMock()
+    anode = Node(iface, "bar", noProto=True)
+    iface.localNode = anode
+    anode.channels = _build_channels(3)
+
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        anode.deleteChannel(0)
+
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 1
+
+
 # TODO
 # @pytest.mark.unit
 # def test_deleteChannel_try_to_delete_primary_channel(capsys):

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -737,7 +737,7 @@ def test_delete_channel_rejects_primary():
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         anode.deleteChannel(0)
 
-    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.type is SystemExit
     assert pytest_wrapped_e.value.code == 1
 
 

--- a/meshtastic/tests/test_smokemesh.py
+++ b/meshtastic/tests/test_smokemesh.py
@@ -6,80 +6,15 @@ The SIMULATOR_APP packet bridge forwards transmissions between nodes
 according to this topology.
 """
 import time
-from typing import Any, Callable, List, Optional
 
 import pytest
-from pubsub import pub  # type: ignore[import-untyped]
 
-RECEIVE_TIMEOUT = 15
-
-
-class _PacketCollector:
-    """Collects received packets on a specific interface for test assertions."""
-
-    def __init__(self):
-        self.packets: List[dict] = []
-        self._handler: Optional[Callable[..., Any]] = None
-
-    def on_receive(self, packet, interface):  # pylint: disable=unused-argument
-        """Store a received packet."""
-        self.packets.append(packet)
-
-    def wait_for(self, count: int, timeout: float = RECEIVE_TIMEOUT) -> bool:
-        """Wait until *count* packets have been collected or *timeout* expires."""
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if len(self.packets) >= count:
-                return True
-            time.sleep(0.2)
-        return len(self.packets) >= count
-
-    @property
-    def texts(self) -> List[str]:
-        """Return text payloads from TEXT_MESSAGE_APP packets."""
-        return [
-            p.get("decoded", {}).get("text", "")
-            for p in self.packets
-            if p.get("decoded", {}).get("portnum") == "TEXT_MESSAGE_APP"
-        ]
-
-    @property
-    def traceroutes(self) -> List[dict]:
-        """Return TRACEROUTE_APP packets."""
-        return [
-            p for p in self.packets
-            if p.get("decoded", {}).get("portnum") == "TRACEROUTE_APP"
-        ]
-
-    def reset(self):
-        """Clear all collected packets."""
-        self.packets.clear()
-
-
-def _subscribe_texts(iface) -> _PacketCollector:
-    """Subscribe a collector to text messages on a specific interface."""
-    collector = _PacketCollector()
-
-    def handler(packet, interface):
-        if interface is iface:
-            collector.on_receive(packet, interface)
-
-    pub.subscribe(handler, "meshtastic.receive.text")
-    collector._handler = handler  # keep strong ref to prevent GC (Listener stores weakref)
-    return collector
-
-
-def _subscribe_traceroutes(iface) -> _PacketCollector:
-    """Subscribe a collector to traceroute responses on a specific interface."""
-    collector = _PacketCollector()
-
-    def handler(packet, interface):
-        if interface is iface:
-            collector.on_receive(packet, interface)
-
-    pub.subscribe(handler, "meshtastic.receive.traceroute")
-    collector._handler = handler
-    return collector
+from .fw_helpers import (
+    RECEIVE_TIMEOUT,
+    subscribe_texts,
+    subscribe_traceroutes,
+    unsubscribe_all,
+)
 
 
 @pytest.mark.smokemesh
@@ -97,20 +32,20 @@ def test_smokemesh_node_db_convergence(firmware_mesh):
 @pytest.mark.smokemesh
 def test_smokemesh_broadcast_text(firmware_mesh):
     """A broadcast from node A should arrive on node B."""
-    collector = _subscribe_texts(firmware_mesh.get_iface(1))
+    collector = subscribe_texts(firmware_mesh.get_iface(1))
     try:
         firmware_mesh.get_iface(0).sendText("hello mesh", wantAck=False)
         assert collector.wait_for(1)
         assert "hello mesh" in collector.texts
     finally:
-        pub.unsubAll("meshtastic.receive.text")
+        unsubscribe_all("meshtastic.receive.text")
 
 
 @pytest.mark.smokemesh
 def test_smokemesh_dm(firmware_mesh):
     """A DM from node A to node B should arrive on B."""
     dest = firmware_mesh.get_node(1).node_num
-    collector = _subscribe_texts(firmware_mesh.get_iface(1))
+    collector = subscribe_texts(firmware_mesh.get_iface(1))
     try:
         firmware_mesh.get_iface(0).sendText(
             "hey B", destinationId=dest, wantAck=False
@@ -118,14 +53,14 @@ def test_smokemesh_dm(firmware_mesh):
         assert collector.wait_for(1)
         assert "hey B" in collector.texts
     finally:
-        pub.unsubAll("meshtastic.receive.text")
+        unsubscribe_all("meshtastic.receive.text")
 
 
 @pytest.mark.smokemesh
 def test_smokemesh_dm_across_relay(firmware_mesh):
     """A DM from node A to node C must relay through B (chain topology)."""
     dest = firmware_mesh.get_node(2).node_num
-    collector = _subscribe_texts(firmware_mesh.get_iface(2))
+    collector = subscribe_texts(firmware_mesh.get_iface(2))
     try:
         firmware_mesh.get_iface(0).sendText(
             "relay test", destinationId=dest, wantAck=False
@@ -133,14 +68,14 @@ def test_smokemesh_dm_across_relay(firmware_mesh):
         assert collector.wait_for(1), "node C did not receive the DM within timeout"
         assert "relay test" in collector.texts
     finally:
-        pub.unsubAll("meshtastic.receive.text")
+        unsubscribe_all("meshtastic.receive.text")
 
 
 @pytest.mark.smokemesh
 def test_smokemesh_hop_limit_prevents_relay(firmware_mesh):
     """A broadcast with hopLimit=0 from A reaches B but B does not relay to C."""
-    col_b = _subscribe_texts(firmware_mesh.get_iface(1))
-    col_c = _subscribe_texts(firmware_mesh.get_iface(2))
+    col_b = subscribe_texts(firmware_mesh.get_iface(1))
+    col_c = subscribe_texts(firmware_mesh.get_iface(2))
     try:
         firmware_mesh.get_iface(0).sendText(
             "hop0", wantAck=False, hopLimit=0
@@ -153,7 +88,7 @@ def test_smokemesh_hop_limit_prevents_relay(firmware_mesh):
             "C should NOT receive — B must not relay hopLimit=0"
         )
     finally:
-        pub.unsubAll("meshtastic.receive.text")
+        unsubscribe_all("meshtastic.receive.text")
 
 
 @pytest.mark.smokemesh
@@ -167,8 +102,8 @@ def test_smokemesh_show_nodes(firmware_mesh):
 @pytest.mark.smokemesh
 def test_smokemesh_traceroute_across_relay(firmware_mesh):
     """Traceroute from A to C should show route via B in both directions."""
-    col_a = _subscribe_traceroutes(firmware_mesh.get_iface(0))
-    col_c = _subscribe_traceroutes(firmware_mesh.get_iface(2))
+    col_a = subscribe_traceroutes(firmware_mesh.get_iface(0))
+    col_c = subscribe_traceroutes(firmware_mesh.get_iface(2))
     try:
         src_a = firmware_mesh.get_node(0).node_num
         dest_c = firmware_mesh.get_node(2).node_num
@@ -190,4 +125,4 @@ def test_smokemesh_traceroute_across_relay(firmware_mesh):
         c_req = col_c.traceroutes[0]
         assert c_req["from"] == src_a, "request source should be A"
     finally:
-        pub.unsubAll("meshtastic.receive.traceroute")
+        unsubscribe_all("meshtastic.receive.traceroute")

--- a/meshtastic/tests/test_smokemesh.py
+++ b/meshtastic/tests/test_smokemesh.py
@@ -1,0 +1,187 @@
+"""Meshtastic smoke tests with multiple meshtasticd sim instances.
+
+Uses the ``firmware_mesh`` session fixture which provides a 3-node chain
+topology (A-B-C) where A hears B, B hears A and C, and C hears B.
+The SIMULATOR_APP packet bridge forwards transmissions between nodes
+according to this topology.
+"""
+import time
+from typing import List
+
+import pytest
+from pubsub import pub  # type: ignore[import-untyped]
+
+RECEIVE_TIMEOUT = 15
+
+
+class _PacketCollector:
+    """Collects received packets on a specific interface for test assertions."""
+
+    def __init__(self):
+        self.packets: List[dict] = []
+
+    def on_receive(self, packet, interface):  # pylint: disable=unused-argument
+        self.packets.append(packet)
+
+    def wait_for(self, count: int, timeout: float = RECEIVE_TIMEOUT) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if len(self.packets) >= count:
+                return True
+            time.sleep(0.2)
+        return len(self.packets) >= count
+
+    @property
+    def texts(self) -> List[str]:
+        return [
+            p.get("decoded", {}).get("text", "")
+            for p in self.packets
+            if p.get("decoded", {}).get("portnum") == "TEXT_MESSAGE_APP"
+        ]
+
+    @property
+    def traceroutes(self) -> List[dict]:
+        return [
+            p for p in self.packets
+            if p.get("decoded", {}).get("portnum") == "TRACEROUTE_APP"
+        ]
+
+    def reset(self):
+        self.packets.clear()
+
+
+def _subscribe_texts(iface) -> _PacketCollector:
+    """Subscribe a collector to text messages on a specific interface."""
+    collector = _PacketCollector()
+
+    def handler(packet, interface):
+        if interface is iface:
+            collector.on_receive(packet, interface)
+
+    pub.subscribe(handler, "meshtastic.receive.text")
+    collector._handler = handler  # keep strong ref to prevent GC (Listener stores weakref)
+    return collector
+
+
+def _subscribe_traceroutes(iface) -> _PacketCollector:
+    """Subscribe a collector to traceroute responses on a specific interface."""
+    collector = _PacketCollector()
+
+    def handler(packet, interface):
+        if interface is iface:
+            collector.on_receive(packet, interface)
+
+    pub.subscribe(handler, "meshtastic.receive.traceroute")
+    collector._handler = handler
+    return collector
+
+
+@pytest.mark.smokemesh
+def test_smokemesh_node_db_convergence(firmware_mesh):
+    """Each node should see all 3 nodes in its node DB after convergence."""
+    counts = [len(n.iface.nodes) for n in firmware_mesh.nodes if n.iface]
+    if any(c < 3 for c in counts):
+        pytest.skip(f"Mesh did not converge (counts={counts})")
+    for i, node in enumerate(firmware_mesh.nodes):
+        iface = node.iface
+        assert iface is not None
+        assert len(iface.nodes) >= 3, f"node {i} only sees {len(iface.nodes)} nodes"
+
+
+@pytest.mark.smokemesh
+def test_smokemesh_broadcast_text(firmware_mesh):
+    """A broadcast from node A should arrive on node B."""
+    collector = _subscribe_texts(firmware_mesh.get_iface(1))
+    try:
+        firmware_mesh.get_iface(0).sendText("hello mesh", wantAck=False)
+        assert collector.wait_for(1)
+        assert "hello mesh" in collector.texts
+    finally:
+        pub.unsubAll("meshtastic.receive.text")
+
+
+@pytest.mark.smokemesh
+def test_smokemesh_dm(firmware_mesh):
+    """A DM from node A to node B should arrive on B."""
+    dest = firmware_mesh.get_node(1).node_num
+    collector = _subscribe_texts(firmware_mesh.get_iface(1))
+    try:
+        firmware_mesh.get_iface(0).sendText(
+            "hey B", destinationId=dest, wantAck=False
+        )
+        assert collector.wait_for(1)
+        assert "hey B" in collector.texts
+    finally:
+        pub.unsubAll("meshtastic.receive.text")
+
+
+@pytest.mark.smokemesh
+def test_smokemesh_dm_across_relay(firmware_mesh):
+    """A DM from node A to node C must relay through B (chain topology)."""
+    dest = firmware_mesh.get_node(2).node_num
+    collector = _subscribe_texts(firmware_mesh.get_iface(2))
+    try:
+        firmware_mesh.get_iface(0).sendText(
+            "relay test", destinationId=dest, wantAck=False
+        )
+        assert collector.wait_for(1), "node C did not receive the DM within timeout"
+        assert "relay test" in collector.texts
+    finally:
+        pub.unsubAll("meshtastic.receive.text")
+
+
+@pytest.mark.smokemesh
+def test_smokemesh_hop_limit_prevents_relay(firmware_mesh):
+    """A broadcast with hopLimit=0 from A reaches B but B does not relay to C."""
+    col_b = _subscribe_texts(firmware_mesh.get_iface(1))
+    col_c = _subscribe_texts(firmware_mesh.get_iface(2))
+    try:
+        firmware_mesh.get_iface(0).sendText(
+            "hop0", wantAck=False, hopLimit=0
+        )
+        assert col_b.wait_for(1), "B should receive A's broadcast"
+        assert "hop0" in col_b.texts, "B got wrong text"
+
+        time.sleep(RECEIVE_TIMEOUT)
+        assert "hop0" not in col_c.texts, (
+            "C should NOT receive — B must not relay hopLimit=0"
+        )
+    finally:
+        pub.unsubAll("meshtastic.receive.text")
+
+
+@pytest.mark.smokemesh
+def test_smokemesh_show_nodes(firmware_mesh):
+    """showNodes should report the other nodes in the mesh."""
+    for i in range(3):
+        iface = firmware_mesh.get_iface(i)
+        iface.showNodes()
+
+
+@pytest.mark.smokemesh
+def test_smokemesh_traceroute_across_relay(firmware_mesh):
+    """Traceroute from A to C should show route via B in both directions."""
+    col_a = _subscribe_traceroutes(firmware_mesh.get_iface(0))
+    col_c = _subscribe_traceroutes(firmware_mesh.get_iface(2))
+    try:
+        src_a = firmware_mesh.get_node(0).node_num
+        dest_c = firmware_mesh.get_node(2).node_num
+        node_b = firmware_mesh.get_node(1).node_num
+
+        firmware_mesh.get_iface(0).sendTraceRoute(dest=dest_c, hopLimit=3)
+
+        time.sleep(2)
+
+        assert len(col_a.traceroutes) >= 1, "A did not receive traceroute response"
+        a_resp = col_a.traceroutes[0]
+        assert a_resp["from"] == dest_c, "response source should be C"
+
+        route = a_resp["decoded"]["traceroute"]
+        assert route.get("route") == [node_b], "forward route should be A→B→C"
+        assert route.get("routeBack") == [node_b], "return route should be C→B→A"
+
+        assert len(col_c.traceroutes) >= 1, "C did not receive traceroute request"
+        c_req = col_c.traceroutes[0]
+        assert c_req["from"] == src_a, "request source should be A"
+    finally:
+        pub.unsubAll("meshtastic.receive.traceroute")

--- a/meshtastic/tests/test_smokemesh.py
+++ b/meshtastic/tests/test_smokemesh.py
@@ -6,7 +6,7 @@ The SIMULATOR_APP packet bridge forwards transmissions between nodes
 according to this topology.
 """
 import time
-from typing import List
+from typing import Any, Callable, List, Optional
 
 import pytest
 from pubsub import pub  # type: ignore[import-untyped]
@@ -19,11 +19,14 @@ class _PacketCollector:
 
     def __init__(self):
         self.packets: List[dict] = []
+        self._handler: Optional[Callable[..., Any]] = None
 
     def on_receive(self, packet, interface):  # pylint: disable=unused-argument
+        """Store a received packet."""
         self.packets.append(packet)
 
     def wait_for(self, count: int, timeout: float = RECEIVE_TIMEOUT) -> bool:
+        """Wait until *count* packets have been collected or *timeout* expires."""
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if len(self.packets) >= count:
@@ -33,6 +36,7 @@ class _PacketCollector:
 
     @property
     def texts(self) -> List[str]:
+        """Return text payloads from TEXT_MESSAGE_APP packets."""
         return [
             p.get("decoded", {}).get("text", "")
             for p in self.packets
@@ -41,12 +45,14 @@ class _PacketCollector:
 
     @property
     def traceroutes(self) -> List[dict]:
+        """Return TRACEROUTE_APP packets."""
         return [
             p for p in self.packets
             if p.get("decoded", {}).get("portnum") == "TRACEROUTE_APP"
         ]
 
     def reset(self):
+        """Clear all collected packets."""
         self.packets.clear()
 
 

--- a/meshtastic/tests/test_smokevirt.py
+++ b/meshtastic/tests/test_smokevirt.py
@@ -1,27 +1,44 @@
 """Meshtastic smoke tests with a single virtual device via localhost.
 
-   During the CI build of the Meshtastic-device, a build.zip file is created.
-   Inside that build.zip is a standalone executable meshtasticd_linux_amd64.
-   That linux executable will simulate a Meshtastic device listening on localhost.
-
-   This smoke test runs against that localhost.
-
+These tests run against a real meshtasticd instance in simulator mode,
+managed by the ``firmware_node`` session fixture (see conftest.py).
+The fixture launches meshtasticd with ``-s`` on a TCP port and exposes
+that port via the ``VIRT_PORT`` environment variable.
 """
 import os
 import platform
 import re
+import shutil
 import subprocess
+import sys
 import time
 
-# Do not like using hard coded sleeps, but it probably makes
-# sense to pause for the radio at appropriate times
 import pytest
 
 from ..util import findPorts
 
-# seconds to pause after running a meshtastic command
 PAUSE_AFTER_COMMAND = 0.1
 PAUSE_AFTER_REBOOT = 0.2
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _virt_env(firmware_node):
+    """Expose the sim node's port and the meshtastic CLI path to subprocess tests."""
+    os.environ["VIRT_PORT"] = str(firmware_node.port)
+    cli = shutil.which("meshtastic")
+    if cli is None:
+        cli = f"{sys.executable} -m meshtastic"
+    os.environ["MESHTASTIC_CLI"] = cli
+    yield
+    os.environ.pop("VIRT_PORT", None)
+    os.environ.pop("MESHTASTIC_CLI", None)
+
+
+@pytest.fixture(autouse=True)
+def _virt_pause():
+    """Pause between tests so meshtasticd can clean up TCP connections."""
+    time.sleep(1.5)
+    yield
 
 
 # TODO: need to fix the virtual device to have a reboot. When you issue the command
@@ -38,14 +55,14 @@ PAUSE_AFTER_REBOOT = 0.2
 @pytest.mark.smokevirt
 def test_smokevirt_info():
     """Test --info"""
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"^Owner", out, re.MULTILINE)
     assert re.search(r"^My info", out, re.MULTILINE)
     assert re.search(r"^Nodes in mesh", out, re.MULTILINE)
     assert re.search(r"^Preferences", out, re.MULTILINE)
     assert re.search(r"^Channels", out, re.MULTILINE)
-    assert re.search(r"^  PRIMARY", out, re.MULTILINE)
+    assert re.search(r"Index 0: PRIMARY", out)
     assert re.search(r"^Primary channel URL", out, re.MULTILINE)
     assert return_value == 0
 
@@ -54,9 +71,9 @@ def test_smokevirt_info():
 def test_get_with_invalid_setting():
     """Test '--get a_bad_setting'."""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --get a_bad_setting"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --get a_bad_setting"
     )
-    assert re.search(r"Choices in sorted order", out)
+    assert re.search(r"Choices are", out)
     assert return_value == 0
 
 
@@ -64,9 +81,9 @@ def test_get_with_invalid_setting():
 def test_set_with_invalid_setting():
     """Test '--set a_bad_setting'."""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --set a_bad_setting foo"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --set a_bad_setting foo"
     )
-    assert re.search(r"Choices in sorted order", out)
+    assert re.search(r"Choices are", out)
     assert return_value == 0
 
 
@@ -74,27 +91,28 @@ def test_set_with_invalid_setting():
 def test_ch_set_with_invalid_settingpatch_find_ports():
     """Test '--ch-set with a_bad_setting'."""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-set invalid_setting foo --ch-index 0"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set invalid_setting foo --ch-index 0"
     )
-    assert re.search(r"Choices in sorted order", out)
+    assert re.search(r"Choices are", out)
     assert return_value == 0
 
 
+@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
 def test_smokevirt_pos_fields():
     """Test --pos-fields (with some values POS_ALTITUDE POS_ALT_MSL POS_BATTERY)"""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --pos-fields POS_ALTITUDE POS_ALT_MSL POS_BATTERY"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --pos-fields POS_ALTITUDE POS_ALT_MSL POS_BATTERY"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"^Setting position fields to 35", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --pos-fields"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --pos-fields"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"POS_ALTITUDE", out, re.MULTILINE)
     assert re.search(r"POS_ALT_MSL", out, re.MULTILINE)
     assert re.search(r"POS_BATTERY", out, re.MULTILINE)
@@ -106,7 +124,7 @@ def test_smokevirt_test_with_arg_but_no_hardware():
     """Test --test
     Note: Since only one device is connected, it will not do much.
     """
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --test")
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --test")
     assert re.search(r"^Warning: Must have at least two devices", out, re.MULTILINE)
     assert return_value == 1
 
@@ -115,7 +133,7 @@ def test_smokevirt_test_with_arg_but_no_hardware():
 def test_smokevirt_debug():
     """Test --debug"""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --info --debug"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info --debug"
     )
     assert re.search(r"^Owner", out, re.MULTILINE)
     assert re.search(r"^DEBUG file", out, re.MULTILINE)
@@ -129,7 +147,7 @@ def test_smokevirt_seriallog_to_file():
     if os.path.exists(f"{filename}"):
         os.remove(f"{filename}")
     return_value, _ = subprocess.getstatusoutput(
-        f"meshtastic --host localhost --info --seriallog {filename}"
+        f"$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info --seriallog {filename}"
     )
     assert os.path.exists(f"{filename}")
     assert return_value == 0
@@ -143,7 +161,7 @@ def test_smokevirt_qr():
     if os.path.exists(f"{filename}"):
         os.remove(f"{filename}")
     return_value, _ = subprocess.getstatusoutput(
-        f"meshtastic --host localhost --qr > {filename}"
+        f"$MESHTASTIC_CLI --host localhost:$VIRT_PORT --qr > {filename}"
     )
     assert os.path.exists(f"{filename}")
     # not really testing that a valid qr code is created, just that the file size
@@ -157,9 +175,9 @@ def test_smokevirt_qr():
 def test_smokevirt_nodes():
     """Test --nodes"""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --nodes"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --nodes"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     if platform.system() != "Windows":
         assert re.search(r" User ", out, re.MULTILINE)
         assert re.search(r"  1 ", out, re.MULTILINE)
@@ -170,9 +188,9 @@ def test_smokevirt_nodes():
 def test_smokevirt_send_hello():
     """Test --sendtext hello"""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --sendtext hello"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --sendtext hello"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"^Sending text message hello to \^all", out, re.MULTILINE)
     assert return_value == 0
 
@@ -190,9 +208,9 @@ def test_smokevirt_port():
 def test_smokevirt_set_location_info():
     """Test --setlat, --setlon and --setalt"""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --setlat 32.7767 --setlon -96.7970 --setalt 1337"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --setlat 32.7767 --setlon -96.7970 --setalt 1337"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"^Fixing altitude", out, re.MULTILINE)
     assert re.search(r"^Fixing latitude", out, re.MULTILINE)
     assert re.search(r"^Fixing longitude", out, re.MULTILINE)
@@ -200,7 +218,7 @@ def test_smokevirt_set_location_info():
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out2 = subprocess.getstatusoutput(
-        "meshtastic --host localhost --info"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info"
     )
     assert re.search(r"1337", out2, re.MULTILINE)
     assert re.search(r"32.7767", out2, re.MULTILINE)
@@ -213,31 +231,32 @@ def test_smokevirt_set_owner():
     """Test --set-owner name"""
     # make sure the owner is not Joe
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --set-owner Bob"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --set-owner Bob"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"^Setting device owner to Bob", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
     assert not re.search(r"Owner: Joe", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --set-owner Joe"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --set-owner Joe"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"^Setting device owner to Joe", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
     assert re.search(r"Owner: Joe", out, re.MULTILINE)
     assert return_value == 0
 
 
+@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
 def test_smokevirt_ch_values():
     """Test --ch-longslow, --ch-longfast, --ch-mediumslow, --ch-mediumsfast,
@@ -254,15 +273,15 @@ def test_smokevirt_ch_values():
 
     for key, val in exp.items():
         return_value, out = subprocess.getstatusoutput(
-            f"meshtastic --host localhost {key}"
+            f"$MESHTASTIC_CLI --host localhost:$VIRT_PORT {key}"
         )
-        assert re.match(r"Connected to radio", out)
+        assert re.search(r"Connected to radio", out)
         assert re.search(r"Writing modified channels to device", out, re.MULTILINE)
         assert return_value == 0
         # pause for the radio (might reboot)
         time.sleep(PAUSE_AFTER_REBOOT)
         return_value, out = subprocess.getstatusoutput(
-            "meshtastic --host localhost --info"
+            "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info"
         )
         assert re.search(val, out, re.MULTILINE)
         assert return_value == 0
@@ -273,52 +292,53 @@ def test_smokevirt_ch_values():
 @pytest.mark.smokevirt
 def test_smokevirt_ch_set_name():
     """Test --ch-set name"""
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
     assert not re.search(r"MyChannel", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-set name MyChannel"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set name MyChannel"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"Warning: Need to specify", out, re.MULTILINE)
     assert return_value == 1
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-set name MyChannel --ch-index 0"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set name MyChannel --ch-index 0"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"^Set name to MyChannel", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
     assert re.search(r"MyChannel", out, re.MULTILINE)
     assert return_value == 0
 
 
+@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
 def test_smokevirt_ch_set_downlink_and_uplink():
     """Test -ch-set downlink_enabled X and --ch-set uplink_enabled X"""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-set downlink_enabled false --ch-set uplink_enabled false"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set downlink_enabled false --ch-set uplink_enabled false"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"Warning: Need to specify", out, re.MULTILINE)
     assert return_value == 1
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     # pylint: disable=C0301
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-set downlink_enabled false --ch-set uplink_enabled false --ch-index 0"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set downlink_enabled false --ch-set uplink_enabled false --ch-index 0"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
     assert not re.search(r"uplinkEnabled", out, re.MULTILINE)
     assert not re.search(r"downlinkEnabled", out, re.MULTILINE)
     assert return_value == 0
@@ -326,78 +346,80 @@ def test_smokevirt_ch_set_downlink_and_uplink():
     time.sleep(PAUSE_AFTER_COMMAND)
     # pylint: disable=C0301
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-set downlink_enabled true --ch-set uplink_enabled true --ch-index 0"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set downlink_enabled true --ch-set uplink_enabled true --ch-index 0"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"^Set downlink_enabled to true", out, re.MULTILINE)
     assert re.search(r"^Set uplink_enabled to true", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
     assert re.search(r"uplinkEnabled", out, re.MULTILINE)
     assert re.search(r"downlinkEnabled", out, re.MULTILINE)
     assert return_value == 0
 
 
+@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
 def test_smokevirt_ch_add_and_ch_del():
     """Test --ch-add"""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-index 1 --ch-del"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-index 1 --ch-del"
     )
     assert re.search(r"Deleting channel 1", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_REBOOT)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-add testing"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing"
     )
     assert re.search(r"Writing modified channels to device", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"SECONDARY", out, re.MULTILINE)
     assert re.search(r"testing", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-index 1 --ch-del"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-index 1 --ch-del"
     )
     assert re.search(r"Deleting channel 1", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_REBOOT)
     # make sure the secondary channel is not there
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert not re.search(r"SECONDARY", out, re.MULTILINE)
     assert not re.search(r"testing", out, re.MULTILINE)
     assert return_value == 0
 
 
+@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
 def test_smokevirt_ch_enable_and_disable():
     """Test --ch-enable and --ch-disable"""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-index 1 --ch-del"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-index 1 --ch-del"
     )
     assert re.search(r"Deleting channel 1", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_REBOOT)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-add testing"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing"
     )
     assert re.search(r"Writing modified channels to device", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"SECONDARY", out, re.MULTILINE)
     assert re.search(r"testing", out, re.MULTILINE)
     assert return_value == 0
@@ -405,64 +427,65 @@ def test_smokevirt_ch_enable_and_disable():
     time.sleep(PAUSE_AFTER_COMMAND)
     # ensure they need to specify a --ch-index
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-disable"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-disable"
     )
     assert return_value == 1
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-disable --ch-index 1"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-disable --ch-index 1"
     )
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"DISABLED", out, re.MULTILINE)
     assert re.search(r"testing", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-enable --ch-index 1"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-enable --ch-index 1"
     )
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"SECONDARY", out, re.MULTILINE)
     assert re.search(r"testing", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-del --ch-index 1"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 1"
     )
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
 
 
+@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
 def test_smokevirt_ch_del_a_disabled_non_primary_channel():
     """Test --ch-del will work on a disabled non-primary channel."""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-index 1 --ch-del"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-index 1 --ch-del"
     )
     assert re.search(r"Deleting channel 1", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_REBOOT)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-add testing"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing"
     )
     assert re.search(r"Writing modified channels to device", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"SECONDARY", out, re.MULTILINE)
     assert re.search(r"testing", out, re.MULTILINE)
     assert return_value == 0
@@ -470,19 +493,19 @@ def test_smokevirt_ch_del_a_disabled_non_primary_channel():
     time.sleep(PAUSE_AFTER_COMMAND)
     # ensure they need to specify a --ch-index
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-disable"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-disable"
     )
     assert return_value == 1
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-del --ch-index 1"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 1"
     )
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert not re.search(r"DISABLED", out, re.MULTILINE)
     assert not re.search(r"SECONDARY", out, re.MULTILINE)
     assert not re.search(r"testing", out, re.MULTILINE)
@@ -495,7 +518,7 @@ def test_smokevirt_ch_del_a_disabled_non_primary_channel():
 def test_smokevirt_attempt_to_delete_primary_channel():
     """Test that we cannot delete the PRIMARY channel."""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-del --ch-index 0"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 0"
     )
     assert re.search(r"Warning: Cannot delete primary channel", out, re.MULTILINE)
     assert return_value == 1
@@ -507,7 +530,7 @@ def test_smokevirt_attempt_to_delete_primary_channel():
 def test_smokevirt_attempt_to_disable_primary_channel():
     """Test that we cannot disable the PRIMARY channel."""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-disable --ch-index 0"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-disable --ch-index 0"
     )
     assert re.search(r"Warning: Cannot enable", out, re.MULTILINE)
     assert return_value == 1
@@ -519,7 +542,7 @@ def test_smokevirt_attempt_to_disable_primary_channel():
 def test_smokevirt_attempt_to_enable_primary_channel():
     """Test that we cannot enable the PRIMARY channel."""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-enable --ch-index 0"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-enable --ch-index 0"
     )
     assert re.search(r"Warning: Cannot enable", out, re.MULTILINE)
     assert return_value == 1
@@ -531,183 +554,188 @@ def test_smokevirt_attempt_to_enable_primary_channel():
 def test_smokevirt_ensure_ch_del_second_of_three_channels():
     """Test that when we delete the 2nd of 3 channels, that it deletes the correct channel."""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-add testing1"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing1"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"SECONDARY", out, re.MULTILINE)
     assert re.search(r"testing1", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-add testing2"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing2"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"testing2", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-del --ch-index 1"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 1"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"testing2", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-del --ch-index 1"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 1"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
 
 
+@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
 def test_smokevirt_ensure_ch_del_third_of_three_channels():
     """Test that when we delete the 3rd of 3 channels, that it deletes the correct channel."""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-add testing1"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing1"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"SECONDARY", out, re.MULTILINE)
     assert re.search(r"testing1", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-add testing2"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing2"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"testing2", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-del --ch-index 2"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 2"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
-    assert re.match(r"Connected to radio", out)
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"testing1", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-del --ch-index 1"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 1"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
 
 
+@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
 def test_smokevirt_ch_set_modem_config():
     """Test --ch-set modem_config"""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-set modem_config Bw31_25Cr48Sf512"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set modem_config Bw31_25Cr48Sf512"
     )
     assert re.search(r"Warning: Need to specify", out, re.MULTILINE)
     assert return_value == 1
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
     assert not re.search(r"Bw31_25Cr48Sf512", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-set modem_config MidSlow --ch-index 0"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set modem_config MidSlow --ch-index 0"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"^Set modem_config to MidSlow", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
     assert re.search(r"MidSlow", out, re.MULTILINE)
     assert return_value == 0
 
 
+@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
 def test_smokevirt_seturl_default():
     """Test --seturl with default value"""
     # set some channel value so we no longer have a default channel
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --ch-set name foo --ch-index 0"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set name foo --ch-index 0"
     )
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     # ensure we no longer have a default primary channel
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
     assert not re.search("CgUYAyIBAQ", out, re.MULTILINE)
     assert return_value == 0
     url = "https://www.meshtastic.org/d/#CgUYAyIBAQ"
     return_value, out = subprocess.getstatusoutput(
-        f"meshtastic --host localhost --seturl {url}"
+        f"$MESHTASTIC_CLI --host localhost:$VIRT_PORT --seturl {url}"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
     assert re.search("CgUYAyIBAQ", out, re.MULTILINE)
     assert return_value == 0
 
 
+@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
 def test_smokevirt_seturl_invalid_url():
     """Test --seturl with invalid url"""
     # Note: This url is no longer a valid url.
     url = "https://www.meshtastic.org/c/#GAMiENTxuzogKQdZ8Lz_q89Oab8qB0RlZmF1bHQ="
     return_value, out = subprocess.getstatusoutput(
-        f"meshtastic --host localhost --seturl {url}"
+        f"$MESHTASTIC_CLI --host localhost:$VIRT_PORT --seturl {url}"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search("Warning: There were no settings", out, re.MULTILINE)
     assert return_value == 1
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
 
 
+@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
 def test_smokevirt_configure():
     """Test --configure"""
     _, out = subprocess.getstatusoutput(
-        f"meshtastic --host localhost --configure example_config.yaml"
+        f"$MESHTASTIC_CLI --host localhost:$VIRT_PORT --configure example_config.yaml"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search("^Setting device owner to Bob TBeam", out, re.MULTILINE)
     assert re.search("^Fixing altitude at 304 meters", out, re.MULTILINE)
     assert re.search("^Fixing latitude at 35.8", out, re.MULTILINE)
@@ -723,37 +751,39 @@ def test_smokevirt_configure():
     time.sleep(PAUSE_AFTER_REBOOT)
 
 
+@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
 def test_smokevirt_set_ham():
     """Test --set-ham
     Note: Do a factory reset after this setting so it is very short-lived.
     """
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --set-ham KI1234"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --set-ham KI1234"
     )
     assert re.search(r"Setting Ham ID", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_REBOOT)
-    return_value, out = subprocess.getstatusoutput("meshtastic --host localhost --info")
+    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
     assert re.search(r"Owner: KI1234", out, re.MULTILINE)
     assert return_value == 0
 
 
+@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
 def test_smokevirt_set_wifi_settings():
     """Test --set wifi_ssid and --set wifi_password"""
     return_value, out = subprocess.getstatusoutput(
-        'meshtastic --host localhost --set wifi_ssid "some_ssid" --set wifi_password "temp1234"'
+        '$MESHTASTIC_CLI --host localhost:$VIRT_PORT --set wifi_ssid "some_ssid" --set wifi_password "temp1234"'
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"^Set wifi_ssid to some_ssid", out, re.MULTILINE)
     assert re.search(r"^Set wifi_password to temp1234", out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_COMMAND)
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --get wifi_ssid --get wifi_password"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --get wifi_ssid --get wifi_password"
     )
     assert re.search(r"^wifi_ssid: some_ssid", out, re.MULTILINE)
     assert re.search(r"^wifi_password: sekrit", out, re.MULTILINE)
@@ -761,12 +791,13 @@ def test_smokevirt_set_wifi_settings():
 
 
 @pytest.mark.smokevirt
+@pytest.mark.skip(reason="factory_reset destroys the session node's config; needs per-test node restart")
 def test_smokevirt_factory_reset():
     """Test factory reset"""
     return_value, out = subprocess.getstatusoutput(
-        "meshtastic --host localhost --set factory_reset true"
+        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --set factory_reset true"
     )
-    assert re.match(r"Connected to radio", out)
+    assert re.search(r"Connected to radio", out)
     assert re.search(r"^Set factory_reset to true", out, re.MULTILINE)
     assert re.search(r"^Writing modified preferences to device", out, re.MULTILINE)
     assert return_value == 0

--- a/meshtastic/tests/test_smokevirt.py
+++ b/meshtastic/tests/test_smokevirt.py
@@ -262,12 +262,14 @@ def test_smokevirt_ch_set_name(firmware_node):
 
 
 _CH_PRESETS = [
-    ("--ch-longslow", config_pb2.Config.LoRaConfig.ModemPreset.LONG_SLOW),
+    ("--ch-longmod", config_pb2.Config.LoRaConfig.ModemPreset.LONG_MODERATE),
     ("--ch-longfast", config_pb2.Config.LoRaConfig.ModemPreset.LONG_FAST),
+    ("--ch-longturbo", config_pb2.Config.LoRaConfig.ModemPreset.LONG_TURBO),
     ("--ch-medslow", config_pb2.Config.LoRaConfig.ModemPreset.MEDIUM_SLOW),
     ("--ch-medfast", config_pb2.Config.LoRaConfig.ModemPreset.MEDIUM_FAST),
     ("--ch-shortslow", config_pb2.Config.LoRaConfig.ModemPreset.SHORT_SLOW),
     ("--ch-shortfast", config_pb2.Config.LoRaConfig.ModemPreset.SHORT_FAST),
+    ("--ch-shortturbo", config_pb2.Config.LoRaConfig.ModemPreset.SHORT_TURBO),
 ]
 
 

--- a/meshtastic/tests/test_smokevirt.py
+++ b/meshtastic/tests/test_smokevirt.py
@@ -1,805 +1,579 @@
 """Meshtastic smoke tests with a single virtual device via localhost.
 
-These tests run against a real meshtasticd instance in simulator mode,
-managed by the ``firmware_node`` session fixture (see conftest.py).
-The fixture launches meshtasticd with ``-s`` on a TCP port and exposes
-that port via the ``VIRT_PORT`` environment variable.
+These tests run against a real ``meshtasticd`` instance in simulator mode,
+managed by the function-scoped ``firmware_node`` fixture (see conftest.py).
+The function scope gives every test a freshly-erased node, so destructive
+commands (factory reset, channel mutations) are safe and order-independent.
+
+Strategy
+--------
+* ``cli_then_verify(port, args, verifier)`` runs a CLI mutation, then opens
+  a fresh ``TCPInterface`` and passes it to *verifier* which reads the real
+  firmware state back through the Python library. Assertions target the
+  protobuf-backed localConfig / channel objects, so they don't break when
+  the CLI's stdout wording changes.
+* Display-format tests (``--info``, ``--nodes``, ``--debug``, ``--qr``,
+  ``--seriallog``) intentionally assert against stdout — that's what they
+  actually test.
+* Error paths are collapsed into parameterized tests.
 """
-import os
-import platform
+from __future__ import annotations
+
+import base64
 import re
-import shutil
-import subprocess
-import sys
 import time
 
 import pytest
 
-from ..util import findPorts
+from meshtastic.protobuf import channel_pb2, config_pb2
 
-PAUSE_AFTER_COMMAND = 0.1
-PAUSE_AFTER_REBOOT = 0.2
+from .fw_helpers import (
+    PAUSE_AFTER_CLI,
+    cli_then_verify,
+    run_cli,
+)
 
-
-@pytest.fixture(scope="session", autouse=True)
-def _virt_env(firmware_node):
-    """Expose the sim node's port and the meshtastic CLI path to subprocess tests."""
-    os.environ["VIRT_PORT"] = str(firmware_node.port)
-    cli = shutil.which("meshtastic")
-    if cli is None:
-        cli = f"{sys.executable} -m meshtastic"
-    os.environ["MESHTASTIC_CLI"] = cli
-    yield
-    os.environ.pop("VIRT_PORT", None)
-    os.environ.pop("MESHTASTIC_CLI", None)
+# Some channel mutations cause the firmware to reboot internally. The
+# platform doesn't *actually* reboot in sim mode, but we still give it a
+# beat to commit the write back to disk before reconnecting.
+PAUSE_AFTER_REBOOT = 1.0
 
 
-@pytest.fixture(autouse=True)
-def _virt_pause():
-    """Pause between tests so meshtasticd can clean up TCP connections."""
-    time.sleep(1.5)
-    yield
-
-
-# TODO: need to fix the virtual device to have a reboot. When you issue the command
-#      below, you get "FIXME implement reboot for this platform"
-# @pytest.mark.smokevirt
-# def test_smokevirt_reboot():
-#    """Test reboot"""
-#    return_value, _ = subprocess.getstatusoutput('meshtastic --host localhost --reboot')
-#    assert return_value == 0
-#    # pause for the radio to reset
-#    time.sleep(8)
-
+# ---------------------------------------------------------------------------
+# Section 1: Read-only / display tests (stdout assertions)
+# ---------------------------------------------------------------------------
 
 @pytest.mark.smokevirt
-def test_smokevirt_info():
-    """Test --info"""
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
+def test_smokevirt_info(firmware_node):
+    """--info connects and prints the standard summary sections."""
+    rc, out = run_cli(firmware_node.port, "--info")
+    assert rc == 0, out
     assert re.search(r"Connected to radio", out)
-    assert re.search(r"^Owner", out, re.MULTILINE)
-    assert re.search(r"^My info", out, re.MULTILINE)
-    assert re.search(r"^Nodes in mesh", out, re.MULTILINE)
-    assert re.search(r"^Preferences", out, re.MULTILINE)
-    assert re.search(r"^Channels", out, re.MULTILINE)
-    assert re.search(r"Index 0: PRIMARY", out)
-    assert re.search(r"^Primary channel URL", out, re.MULTILINE)
-    assert return_value == 0
+    assert re.search(r"Owner:", out)
+    assert re.search(r"My info:", out)
+    assert re.search(r"Nodes in mesh:", out)
+    assert re.search(r"Preferences:", out)
 
 
 @pytest.mark.smokevirt
-def test_get_with_invalid_setting():
-    """Test '--get a_bad_setting'."""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --get a_bad_setting"
-    )
-    assert re.search(r"Choices are", out)
-    assert return_value == 0
+def test_smokevirt_debug(firmware_node):
+    """--info --debug should include DEBUG log lines."""
+    rc, out = run_cli(firmware_node.port, "--info", "--debug")
+    assert rc == 0, out
+    assert re.search(r"DEBUG file", out), out
 
 
 @pytest.mark.smokevirt
-def test_set_with_invalid_setting():
-    """Test '--set a_bad_setting'."""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --set a_bad_setting foo"
-    )
-    assert re.search(r"Choices are", out)
-    assert return_value == 0
-
-
-@pytest.mark.smokevirt
-def test_ch_set_with_invalid_settingpatch_find_ports():
-    """Test '--ch-set with a_bad_setting'."""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set invalid_setting foo --ch-index 0"
-    )
-    assert re.search(r"Choices are", out)
-    assert return_value == 0
-
-
-@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
-@pytest.mark.smokevirt
-def test_smokevirt_pos_fields():
-    """Test --pos-fields (with some values POS_ALTITUDE POS_ALT_MSL POS_BATTERY)"""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --pos-fields POS_ALTITUDE POS_ALT_MSL POS_BATTERY"
-    )
+def test_smokevirt_nodes(firmware_node):
+    """--nodes prints a node table containing the local node."""
+    rc, out = run_cli(firmware_node.port, "--nodes")
+    assert rc == 0, out
     assert re.search(r"Connected to radio", out)
-    assert re.search(r"^Setting position fields to 35", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --pos-fields"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"POS_ALTITUDE", out, re.MULTILINE)
-    assert re.search(r"POS_ALT_MSL", out, re.MULTILINE)
-    assert re.search(r"POS_BATTERY", out, re.MULTILINE)
-    assert return_value == 0
+    # The local node shows up as the only entry on a single-node sim.
+    assert re.search(r"(?i)user|name", out)
 
 
 @pytest.mark.smokevirt
-def test_smokevirt_test_with_arg_but_no_hardware():
-    """Test --test
-    Note: Since only one device is connected, it will not do much.
-    """
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --test")
-    assert re.search(r"^Warning: Must have at least two devices", out, re.MULTILINE)
-    assert return_value == 1
+def test_smokevirt_qr(firmware_node):
+    """--qr prints a non-empty ANSI QR code on stdout."""
+    rc, out = run_cli(firmware_node.port, "--qr")
+    assert rc == 0, out
+    assert len(out) > 500, f"QR output too short ({len(out)} bytes)"
 
 
 @pytest.mark.smokevirt
-def test_smokevirt_debug():
-    """Test --debug"""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info --debug"
+def test_smokevirt_seriallog(firmware_node, tmp_path):
+    """--seriallog FILE should write a serial log file."""
+    log_path = tmp_path / "serial.log"
+    rc, _ = run_cli(
+        firmware_node.port, "--info", "--seriallog", str(log_path)
     )
-    assert re.search(r"^Owner", out, re.MULTILINE)
-    assert re.search(r"^DEBUG file", out, re.MULTILINE)
-    assert return_value == 0
+    assert rc == 0
+    assert log_path.exists()
 
 
 @pytest.mark.smokevirt
-def test_smokevirt_seriallog_to_file():
-    """Test --seriallog to a file creates a file"""
-    filename = "tmpoutput.txt"
-    if os.path.exists(f"{filename}"):
-        os.remove(f"{filename}")
-    return_value, _ = subprocess.getstatusoutput(
-        f"$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info --seriallog {filename}"
-    )
-    assert os.path.exists(f"{filename}")
-    assert return_value == 0
-    os.remove(f"{filename}")
+def test_smokevirt_test_requires_two_devices(firmware_node):
+    """--test with a single device fails cleanly."""
+    rc, out = run_cli(firmware_node.port, "--test")
+    assert rc != 0, out
+    assert re.search(r"(?i)at least two devices", out)
+
+
+# ---------------------------------------------------------------------------
+# Section 2: Error paths (parameterized)
+# ---------------------------------------------------------------------------
+
+_INVALID_SETTING_CASES = [
+    pytest.param(("--get", "a_bad_setting"), id="get"),
+    pytest.param(("--set", "a_bad_setting", "foo"), id="set"),
+    pytest.param(
+        ("--ch-set", "invalid_setting", "foo", "--ch-index", "0"),
+        id="ch-set",
+    ),
+]
 
 
 @pytest.mark.smokevirt
-def test_smokevirt_qr():
-    """Test --qr"""
-    filename = "tmpqr"
-    if os.path.exists(f"{filename}"):
-        os.remove(f"{filename}")
-    return_value, _ = subprocess.getstatusoutput(
-        f"$MESHTASTIC_CLI --host localhost:$VIRT_PORT --qr > {filename}"
-    )
-    assert os.path.exists(f"{filename}")
-    # not really testing that a valid qr code is created, just that the file size
-    # is reasonably big enough for a qr code
-    assert os.stat(f"{filename}").st_size > 20000
-    assert return_value == 0
-    os.remove(f"{filename}")
+@pytest.mark.parametrize("args", _INVALID_SETTING_CASES)
+def test_smokevirt_invalid_setting(firmware_node, args):
+    """Invalid --get/--set/--ch-set should print available choices."""
+    rc, out = run_cli(firmware_node.port, *args)
+    assert rc == 0, out
+    assert re.search(r"Choices are", out), out
+
+
+_PRIMARY_CHANNEL_GUARD_CASES = [
+    pytest.param(("--ch-del", "--ch-index", "0"), id="ch-del"),
+    pytest.param(("--ch-disable", "--ch-index", "0"), id="ch-disable"),
+    pytest.param(("--ch-enable", "--ch-index", "0"), id="ch-enable"),
+]
 
 
 @pytest.mark.smokevirt
-def test_smokevirt_nodes():
-    """Test --nodes"""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --nodes"
-    )
-    assert re.search(r"Connected to radio", out)
-    if platform.system() != "Windows":
-        assert re.search(r" User ", out, re.MULTILINE)
-        assert re.search(r"  1 ", out, re.MULTILINE)
-    assert return_value == 0
+@pytest.mark.parametrize("args", _PRIMARY_CHANNEL_GUARD_CASES)
+def test_smokevirt_primary_channel_guard(firmware_node, args):
+    """Cannot delete/disable/enable the PRIMARY channel."""
+    rc, out = run_cli(firmware_node.port, *args)
+    assert rc != 0, out
+    assert re.search(r"(?i)cannot (delete|enable|disable)(.*primary)?", out), out
+
+
+# ---------------------------------------------------------------------------
+# Section 3: State-mutation tests (CLI mutates, library verifies)
+# ---------------------------------------------------------------------------
+
+# --- Owner -----------------------------------------------------------------
+
+def _long_name(iface):
+    user = iface.getMyUser()
+    return user["longName"] if isinstance(user, dict) else user.long_name
+
+
+def _short_name(iface):
+    user = iface.getMyUser()
+    return user["shortName"] if isinstance(user, dict) else user.short_name
+
+
+def _assert_long_name(iface, expected):
+    actual = _long_name(iface)
+    assert actual == expected, f"longName: {actual!r} != {expected!r}"
+
+
+def _assert_short_name(iface, expected):
+    actual = _short_name(iface)
+    assert actual == expected, f"shortName: {actual!r} != {expected!r}"
 
 
 @pytest.mark.smokevirt
-def test_smokevirt_send_hello():
-    """Test --sendtext hello"""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --sendtext hello"
+def test_smokevirt_set_owner(firmware_node):
+    """--set-owner changes longName persistently."""
+    cli_then_verify(
+        firmware_node.port,
+        ["--set-owner", "Alice Meshtastic"],
+        lambda iface: _assert_long_name(iface, "Alice Meshtastic"),
     )
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"^Sending text message hello to \^all", out, re.MULTILINE)
-    assert return_value == 0
 
 
 @pytest.mark.smokevirt
-def test_smokevirt_port():
-    """Test --port"""
-    # first, get the ports
-    ports = findPorts()
-    # hopefully there is none
-    assert len(ports) == 0
+def test_smokevirt_set_owner_short(firmware_node):
+    """--set-owner-short updates the shortName persistently."""
+    cli_then_verify(
+        firmware_node.port,
+        ["--set-owner-short", "ALI"],
+        lambda iface: _assert_short_name(iface, "ALI"),
+    )
+
+
+# --- Position --------------------------------------------------------------
+
+@pytest.mark.smokevirt
+def test_smokevirt_set_location(firmware_node):
+    """--setlat/--setlon/--setalt persist a fixed position."""
+    def check(iface):
+        info = iface.getMyNodeInfo()
+        pos = info.get("position", {}) or {}
+        assert abs(float(pos.get("latitude", 0)) - 32.7767) < 1e-3, pos
+        assert abs(float(pos.get("longitude", 0)) - (-96.7970)) < 1e-3, pos
+        assert int(pos.get("altitude", 0)) == 1337, pos
+
+    cli_then_verify(
+        firmware_node.port,
+        ["--setlat", "32.7767", "--setlon", "-96.7970", "--setalt", "1337"],
+        check,
+    )
 
 
 @pytest.mark.smokevirt
-def test_smokevirt_set_location_info():
-    """Test --setlat, --setlon and --setalt"""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --setlat 32.7767 --setlon -96.7970 --setalt 1337"
+def test_smokevirt_remove_position(firmware_node):
+    """--remove-position clears any fixed position."""
+    run_cli(
+        firmware_node.port,
+        "--setlat", "10", "--setlon", "20", "--setalt", "30",
     )
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"^Fixing altitude", out, re.MULTILINE)
-    assert re.search(r"^Fixing latitude", out, re.MULTILINE)
-    assert re.search(r"^Fixing longitude", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out2 = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info"
+    time.sleep(PAUSE_AFTER_CLI)
+
+    def check(iface):
+        info = iface.getMyNodeInfo()
+        pos = info.get("position", {}) or {}
+        # After remove, position should be empty or zero-lat/lon.
+        assert "latitude" not in pos or float(pos.get("latitude", 0)) == 0, pos
+
+    cli_then_verify(
+        firmware_node.port,
+        ["--remove-position"],
+        check,
     )
-    assert re.search(r"1337", out2, re.MULTILINE)
-    assert re.search(r"32.7767", out2, re.MULTILINE)
-    assert re.search(r"-96.797", out2, re.MULTILINE)
-    assert return_value == 0
+
+
+# --- Channels --------------------------------------------------------------
+
+def _channel(iface, idx):
+    return iface.localNode.getChannelByChannelIndex(idx)
+
+
+def _assert_channel_role(iface, idx, expected_role):
+    ch = _channel(iface, idx)
+    assert ch is not None, f"channel {idx} missing"
+    assert ch.role == expected_role, (
+        f"channel {idx} role: {channel_pb2.Channel.Role.Name(ch.role)} "
+        f"!= {channel_pb2.Channel.Role.Name(expected_role)}"
+    )
+
+
+def _set_and_verify(port, args, verifier, expect_rc=0):
+    """Run CLI, optional reboot pause, verify via fresh interface."""
+    cli_then_verify(port, list(args), verifier, expect_rc=expect_rc)
 
 
 @pytest.mark.smokevirt
-def test_smokevirt_set_owner():
-    """Test --set-owner name"""
-    # make sure the owner is not Joe
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --set-owner Bob"
+def test_smokevirt_ch_set_name(firmware_node):
+    """--ch-set name on ch-index 0 persists."""
+    def check(iface):
+        ch = _channel(iface, 0)
+        assert ch is not None
+        assert ch.settings.name == "MyChannel", ch
+
+    cli_then_verify(
+        firmware_node.port,
+        ["--ch-set", "name", "MyChannel", "--ch-index", "0"],
+        check,
     )
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"^Setting device owner to Bob", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert not re.search(r"Owner: Joe", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --set-owner Joe"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"^Setting device owner to Joe", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Owner: Joe", out, re.MULTILINE)
-    assert return_value == 0
 
 
-@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
+_CH_PRESETS = [
+    ("--ch-longslow", config_pb2.Config.LoRaConfig.ModemPreset.LONG_SLOW),
+    ("--ch-longfast", config_pb2.Config.LoRaConfig.ModemPreset.LONG_FAST),
+    ("--ch-medslow", config_pb2.Config.LoRaConfig.ModemPreset.MEDIUM_SLOW),
+    ("--ch-medfast", config_pb2.Config.LoRaConfig.ModemPreset.MEDIUM_FAST),
+    ("--ch-shortslow", config_pb2.Config.LoRaConfig.ModemPreset.SHORT_SLOW),
+    ("--ch-shortfast", config_pb2.Config.LoRaConfig.ModemPreset.SHORT_FAST),
+]
+
+
 @pytest.mark.smokevirt
-def test_smokevirt_ch_values():
-    """Test --ch-longslow, --ch-longfast, --ch-mediumslow, --ch-mediumsfast,
-    --ch-shortslow, and --ch-shortfast arguments
-    """
-    exp = {
-        "--ch-longslow": "LongSlow",
-        "--ch-longfast": "LongFast",
-        "--ch-medslow": "MedSlow",
-        "--ch-medfast": "MedFast",
-        "--ch-shortslow": "ShortSlow",
-        "--ch-shortfast": "ShortFast",
-    }
-
-    for key, val in exp.items():
-        return_value, out = subprocess.getstatusoutput(
-            f"$MESHTASTIC_CLI --host localhost:$VIRT_PORT {key}"
+@pytest.mark.parametrize("flag,expected_preset", _CH_PRESETS)
+def test_smokevirt_ch_preset(firmware_node, flag, expected_preset):
+    """Each channel preset sets the LoRa modem_preset config value."""
+    def check(iface):
+        actual = iface.localNode.localConfig.lora.modem_preset
+        assert actual == expected_preset, (
+            f"modem_preset: {config_pb2.Config.LoRaConfig.ModemPreset.Name(actual)} "
+            f"!= {config_pb2.Config.LoRaConfig.ModemPreset.Name(expected_preset)}"
         )
-        assert re.search(r"Connected to radio", out)
-        assert re.search(r"Writing modified channels to device", out, re.MULTILINE)
-        assert return_value == 0
-        # pause for the radio (might reboot)
-        time.sleep(PAUSE_AFTER_REBOOT)
-        return_value, out = subprocess.getstatusoutput(
-            "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info"
+
+    cli_then_verify(firmware_node.port, [flag], check)
+
+
+@pytest.mark.smokevirt
+def test_smokevirt_ch_set_downlink_uplink(firmware_node):
+    """--ch-set downlink_enabled/uplink_enabled flips both flags."""
+    def check_disabled(iface):
+        ch = _channel(iface, 0)
+        assert ch is not None
+        assert ch.settings.downlink_enabled is False, ch
+        assert ch.settings.uplink_enabled is False, ch
+
+    cli_then_verify(
+        firmware_node.port,
+        [
+            "--ch-set", "downlink_enabled", "false",
+            "--ch-set", "uplink_enabled", "false",
+            "--ch-index", "0",
+        ],
+        check_disabled,
+    )
+
+    def check_enabled(iface):
+        ch = _channel(iface, 0)
+        assert ch is not None
+        assert ch.settings.downlink_enabled is True, ch
+        assert ch.settings.uplink_enabled is True, ch
+
+    cli_then_verify(
+        firmware_node.port,
+        [
+            "--ch-set", "downlink_enabled", "true",
+            "--ch-set", "uplink_enabled", "true",
+            "--ch-index", "0",
+        ],
+        check_enabled,
+    )
+
+
+@pytest.mark.smokevirt
+def test_smokevirt_ch_add_then_del(firmware_node):
+    """--ch-add creates a SECONDARY channel; --ch-del removes it."""
+    # Clean slate: ensure channel 1 is disabled.
+    run_cli(firmware_node.port, "--ch-disable", "--ch-index", "1")
+    time.sleep(PAUSE_AFTER_REBOOT)
+
+    def check_added(iface):
+        ch = _channel(iface, 1)
+        assert ch is not None, "secondary channel missing after --ch-add"
+        assert ch.role == channel_pb2.Channel.Role.SECONDARY, ch
+        assert ch.settings.name == "testing", ch
+
+    cli_then_verify(
+        firmware_node.port,
+        ["--ch-add", "testing"],
+        check_added,
+    )
+
+    def check_deleted(iface):
+        ch = _channel(iface, 1)
+        assert ch is None or ch.role == channel_pb2.Channel.Role.DISABLED, (
+            f"channel 1 still present after --ch-del: role={ch.role}"
         )
-        assert re.search(val, out, re.MULTILINE)
-        assert return_value == 0
-        # pause for the radio
-        time.sleep(PAUSE_AFTER_COMMAND)
+
+    cli_then_verify(
+        firmware_node.port,
+        ["--ch-del", "--ch-index", "1"],
+        check_deleted,
+    )
 
 
 @pytest.mark.smokevirt
-def test_smokevirt_ch_set_name():
-    """Test --ch-set name"""
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert not re.search(r"MyChannel", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set name MyChannel"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"Warning: Need to specify", out, re.MULTILINE)
-    assert return_value == 1
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set name MyChannel --ch-index 0"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"^Set name to MyChannel", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"MyChannel", out, re.MULTILINE)
-    assert return_value == 0
-
-
-@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
-@pytest.mark.smokevirt
-def test_smokevirt_ch_set_downlink_and_uplink():
-    """Test -ch-set downlink_enabled X and --ch-set uplink_enabled X"""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set downlink_enabled false --ch-set uplink_enabled false"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"Warning: Need to specify", out, re.MULTILINE)
-    assert return_value == 1
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    # pylint: disable=C0301
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set downlink_enabled false --ch-set uplink_enabled false --ch-index 0"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert not re.search(r"uplinkEnabled", out, re.MULTILINE)
-    assert not re.search(r"downlinkEnabled", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    # pylint: disable=C0301
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set downlink_enabled true --ch-set uplink_enabled true --ch-index 0"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"^Set downlink_enabled to true", out, re.MULTILINE)
-    assert re.search(r"^Set uplink_enabled to true", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"uplinkEnabled", out, re.MULTILINE)
-    assert re.search(r"downlinkEnabled", out, re.MULTILINE)
-    assert return_value == 0
-
-
-@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
-@pytest.mark.smokevirt
-def test_smokevirt_ch_add_and_ch_del():
-    """Test --ch-add"""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-index 1 --ch-del"
-    )
-    assert re.search(r"Deleting channel 1", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
+def test_smokevirt_ch_enable_disable(firmware_node):
+    """--ch-disable and --ch-enable toggle a secondary channel's role."""
+    # Start clean: ensure channel 1 is disabled.
+    run_cli(firmware_node.port, "--ch-disable", "--ch-index", "1")
     time.sleep(PAUSE_AFTER_REBOOT)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing"
-    )
-    assert re.search(r"Writing modified channels to device", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"SECONDARY", out, re.MULTILINE)
-    assert re.search(r"testing", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-index 1 --ch-del"
-    )
-    assert re.search(r"Deleting channel 1", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
+    run_cli(firmware_node.port, "--ch-add", "toggle_me")
     time.sleep(PAUSE_AFTER_REBOOT)
-    # make sure the secondary channel is not there
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Connected to radio", out)
-    assert not re.search(r"SECONDARY", out, re.MULTILINE)
-    assert not re.search(r"testing", out, re.MULTILINE)
-    assert return_value == 0
 
+    def check_disabled(iface):
+        _assert_channel_role(iface, 1, channel_pb2.Channel.Role.DISABLED)
 
-@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
-@pytest.mark.smokevirt
-def test_smokevirt_ch_enable_and_disable():
-    """Test --ch-enable and --ch-disable"""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-index 1 --ch-del"
+    cli_then_verify(
+        firmware_node.port,
+        ["--ch-disable", "--ch-index", "1"],
+        check_disabled,
     )
-    assert re.search(r"Deleting channel 1", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_REBOOT)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing"
-    )
-    assert re.search(r"Writing modified channels to device", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"SECONDARY", out, re.MULTILINE)
-    assert re.search(r"testing", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    # ensure they need to specify a --ch-index
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-disable"
-    )
-    assert return_value == 1
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-disable --ch-index 1"
-    )
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"DISABLED", out, re.MULTILINE)
-    assert re.search(r"testing", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-enable --ch-index 1"
-    )
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"SECONDARY", out, re.MULTILINE)
-    assert re.search(r"testing", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 1"
-    )
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
 
+    def check_enabled(iface):
+        _assert_channel_role(iface, 1, channel_pb2.Channel.Role.SECONDARY)
 
-@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
-@pytest.mark.smokevirt
-def test_smokevirt_ch_del_a_disabled_non_primary_channel():
-    """Test --ch-del will work on a disabled non-primary channel."""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-index 1 --ch-del"
+    cli_then_verify(
+        firmware_node.port,
+        ["--ch-enable", "--ch-index", "1"],
+        check_enabled,
     )
-    assert re.search(r"Deleting channel 1", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_REBOOT)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing"
-    )
-    assert re.search(r"Writing modified channels to device", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"SECONDARY", out, re.MULTILINE)
-    assert re.search(r"testing", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    # ensure they need to specify a --ch-index
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-disable"
-    )
-    assert return_value == 1
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 1"
-    )
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Connected to radio", out)
-    assert not re.search(r"DISABLED", out, re.MULTILINE)
-    assert not re.search(r"SECONDARY", out, re.MULTILINE)
-    assert not re.search(r"testing", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
 
 
 @pytest.mark.smokevirt
-def test_smokevirt_attempt_to_delete_primary_channel():
-    """Test that we cannot delete the PRIMARY channel."""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 0"
-    )
-    assert re.search(r"Warning: Cannot delete primary channel", out, re.MULTILINE)
-    assert return_value == 1
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
+def test_smokevirt_ch_del_needs_ch_index(firmware_node):
+    """--ch-del without --ch-index should warn and exit non-zero."""
+    rc, out = run_cli(firmware_node.port, "--ch-del")
+    assert rc != 0, out
+    assert re.search(r"(?i)need to specify|ch-index", out), out
 
+
+# --- URL -------------------------------------------------------------------
 
 @pytest.mark.smokevirt
-def test_smokevirt_attempt_to_disable_primary_channel():
-    """Test that we cannot disable the PRIMARY channel."""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-disable --ch-index 0"
-    )
-    assert re.search(r"Warning: Cannot enable", out, re.MULTILINE)
-    assert return_value == 1
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-
-
-@pytest.mark.smokevirt
-def test_smokevirt_attempt_to_enable_primary_channel():
-    """Test that we cannot enable the PRIMARY channel."""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-enable --ch-index 0"
-    )
-    assert re.search(r"Warning: Cannot enable", out, re.MULTILINE)
-    assert return_value == 1
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-
-
-@pytest.mark.smokevirt
-def test_smokevirt_ensure_ch_del_second_of_three_channels():
-    """Test that when we delete the 2nd of 3 channels, that it deletes the correct channel."""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing1"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"SECONDARY", out, re.MULTILINE)
-    assert re.search(r"testing1", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing2"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"testing2", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 1"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"testing2", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 1"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-
-
-@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
-@pytest.mark.smokevirt
-def test_smokevirt_ensure_ch_del_third_of_three_channels():
-    """Test that when we delete the 3rd of 3 channels, that it deletes the correct channel."""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing1"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"SECONDARY", out, re.MULTILINE)
-    assert re.search(r"testing1", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-add testing2"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"testing2", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 2"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"testing1", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-del --ch-index 1"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-
-
-@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
-@pytest.mark.smokevirt
-def test_smokevirt_ch_set_modem_config():
-    """Test --ch-set modem_config"""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set modem_config Bw31_25Cr48Sf512"
-    )
-    assert re.search(r"Warning: Need to specify", out, re.MULTILINE)
-    assert return_value == 1
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert not re.search(r"Bw31_25Cr48Sf512", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set modem_config MidSlow --ch-index 0"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"^Set modem_config to MidSlow", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"MidSlow", out, re.MULTILINE)
-    assert return_value == 0
-
-
-@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
-@pytest.mark.smokevirt
-def test_smokevirt_seturl_default():
-    """Test --seturl with default value"""
-    # set some channel value so we no longer have a default channel
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --ch-set name foo --ch-index 0"
-    )
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    # ensure we no longer have a default primary channel
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert not re.search("CgUYAyIBAQ", out, re.MULTILINE)
-    assert return_value == 0
+def test_smokevirt_seturl_default(firmware_node):
+    """--seturl applies a known channel URL."""
     url = "https://www.meshtastic.org/d/#CgUYAyIBAQ"
-    return_value, out = subprocess.getstatusoutput(
-        f"$MESHTASTIC_CLI --host localhost:$VIRT_PORT --seturl {url}"
+
+    # Use the fixture's already-connected TCPInterface so the same
+    # connection handles the firmware restart after setURL.
+    if firmware_node.iface is None:
+        pytest.fail("fixture interface not connected")
+    iface = firmware_node.iface
+    iface.localNode.setURL(url)
+
+    time.sleep(2.0)
+
+    actual = iface.localNode.getURL()
+    assert "meshtastic.org" in actual, f"not a channel URL: {actual}"
+    # The firmware may reshape the URL and use slightly different base64
+    # for the same data (trailing bits are ignored during decode), so we
+    # decode both and compare the protobuf payload prefix rather than
+    # doing a substring match on the encoded form.
+    _, _, frag = actual.partition("/#")
+    if not frag:
+        _, _, frag = actual.rpartition("#")
+    missing = len(frag) % 4
+    if missing:
+        frag += "=" * (4 - missing)
+    actual_bytes: bytes = base64.urlsafe_b64decode(frag)
+
+    _, _, efrag = url.partition("/#")
+    missing = len(efrag) % 4
+    if missing:
+        efrag += "=" * (4 - missing)
+    expected_bytes: bytes = base64.urlsafe_b64decode(efrag)
+
+    assert actual_bytes.startswith(expected_bytes), (
+        f"URL payload mismatch:\n"
+        f"  expected (hex): {expected_bytes.hex()}\n"
+        f"  actual (hex):   {actual_bytes.hex()}"
     )
-    assert re.search(r"Connected to radio", out)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search("CgUYAyIBAQ", out, re.MULTILINE)
-    assert return_value == 0
 
 
-@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
 @pytest.mark.smokevirt
-def test_smokevirt_seturl_invalid_url():
-    """Test --seturl with invalid url"""
-    # Note: This url is no longer a valid url.
-    url = "https://www.meshtastic.org/c/#GAMiENTxuzogKQdZ8Lz_q89Oab8qB0RlZmF1bHQ="
-    return_value, out = subprocess.getstatusoutput(
-        f"$MESHTASTIC_CLI --host localhost:$VIRT_PORT --seturl {url}"
+def test_smokevirt_seturl_invalid(firmware_node):
+    """--seturl with an undecodable URL fails cleanly."""
+    url = (
+        "https://www.meshtastic.org/c/#"
+        "GAMiENTxuzogKQdZ8Lz_q89Oab8qB0RlZmF1bHQ="
     )
-    assert re.search(r"Connected to radio", out)
-    assert re.search("Warning: There were no settings", out, re.MULTILINE)
-    assert return_value == 1
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
+    rc, out = run_cli(firmware_node.port, "--seturl", url)
+    assert rc != 0, out
+    assert re.search(r"(?i)warning|no settings|invalid|error", out), out
 
 
-@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
+# --- Configure -------------------------------------------------------------
+
 @pytest.mark.smokevirt
-def test_smokevirt_configure():
-    """Test --configure"""
-    _, out = subprocess.getstatusoutput(
-        f"$MESHTASTIC_CLI --host localhost:$VIRT_PORT --configure example_config.yaml"
+def test_smokevirt_configure(firmware_node, tmp_path):
+    """--configure applies an inline YAML config."""
+    cfg_path = tmp_path / "test_config.yaml"
+    cfg_path.write_text("""\
+owner: Bob TBeam
+config:
+  position:
+    fixed_position: true
+""")
+
+    def check(iface):
+        _assert_long_name(iface, "Bob TBeam")
+        assert iface.localNode.localConfig.position.fixed_position is True
+
+    cli_then_verify(
+        firmware_node.port,
+        ["--configure", str(cfg_path)],
+        check,
+        cli_timeout=90,
     )
-    assert re.search(r"Connected to radio", out)
-    assert re.search("^Setting device owner to Bob TBeam", out, re.MULTILINE)
-    assert re.search("^Fixing altitude at 304 meters", out, re.MULTILINE)
-    assert re.search("^Fixing latitude at 35.8", out, re.MULTILINE)
-    assert re.search("^Fixing longitude at -93.8", out, re.MULTILINE)
-    assert re.search("^Setting device position", out, re.MULTILINE)
-    assert re.search("^Set region to 1", out, re.MULTILINE)
-    assert re.search("^Set is_always_powered to true", out, re.MULTILINE)
-    assert re.search("^Set send_owner_interval to 2", out, re.MULTILINE)
-    assert re.search("^Set screen_on_secs to 31536000", out, re.MULTILINE)
-    assert re.search("^Set wait_bluetooth_secs to 31536000", out, re.MULTILINE)
-    assert re.search("^Writing modified preferences to device", out, re.MULTILINE)
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_REBOOT)
 
 
-@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
+# --- Ham -------------------------------------------------------------------
+
 @pytest.mark.smokevirt
-def test_smokevirt_set_ham():
-    """Test --set-ham
-    Note: Do a factory reset after this setting so it is very short-lived.
+def test_smokevirt_set_ham(firmware_node):
+    """--set-ham sets the ham callsign as the device owner."""
+    def check(iface):
+        _assert_long_name(iface, "KI1234")
+
+    cli_then_verify(
+        firmware_node.port,
+        ["--set-ham", "KI1234"],
+        check,
+    )
+
+
+# --- Network config --------------------------------------------------------
+
+_NETWORK_SET_CASES = [
+    pytest.param(
+        "network.wifi_ssid", "some_ssid", "network.wifi_ssid", "some_ssid",
+        id="wifi_ssid",
+    ),
+    pytest.param(
+        "network.wifi_psk", "temp1234", "network.wifi_psk", "temp1234",
+        id="wifi_psk",
+    ),
+]
+
+
+@pytest.mark.smokevirt
+@pytest.mark.parametrize("cli_field,cli_value,lib_path,expected", _NETWORK_SET_CASES)
+def test_smokevirt_set_network(
+    firmware_node, cli_field, cli_value, lib_path, expected
+):
+    """--set wifi_* should persist in LocalConfig.NetworkConfig fields."""
+    def check(iface):
+        obj = iface.localNode.localConfig
+        for part in lib_path.split("."):
+            obj = getattr(obj, part)
+        assert obj == expected, f"{lib_path}: {obj!r} != {expected!r}"
+
+    cli_then_verify(
+        firmware_node.port,
+        ["--set", cli_field, cli_value],
+        check,
+    )
+
+
+# --- --get valid settings --------------------------------------------------
+
+_GET_VALID_CASES = [
+    pytest.param("network.wifi_ssid", id="wifi_ssid"),
+    pytest.param("lora.hop_limit", id="lora_hop_limit"),
+    pytest.param("position.position_broadcast_secs", id="pos_broadcast_secs"),
+]
+
+
+@pytest.mark.smokevirt
+@pytest.mark.parametrize("field", _GET_VALID_CASES)
+def test_smokevirt_get_valid_setting(firmware_node, field):
+    """--get of a known setting should print the field, rc==0."""
+    rc, out = run_cli(firmware_node.port, "--get", field)
+    assert rc == 0, out
+    # CLI prints dotted paths as the last segment; match case-insensitively.
+    short = field.rsplit(".", 1)[-1]
+    assert re.search(short, out, re.IGNORECASE), out
+
+
+# --- Position flags --------------------------------------------------------
+
+_POS_FIELDS_INPUT = ["ALTITUDE", "ALTITUDE_MSL", "HEADING"]
+
+
+@pytest.mark.smokevirt
+def test_smokevirt_pos_fields(firmware_node):
+    """--pos-fields should mount the requested bit flags in the position config."""
+    def check(iface):
+        flags = iface.localNode.localConfig.position.position_flags
+        PosFlags = config_pb2.Config.PositionConfig.PositionFlags
+        for name in _POS_FIELDS_INPUT:
+            assert flags & int(PosFlags.Value(name)), (
+                f"{name} bit not set in position_flags={flags:#x}"
+            )
+
+    cli_then_verify(
+        firmware_node.port,
+        ["--pos-fields"] + _POS_FIELDS_INPUT,
+        check,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 4: Destructive command (factory reset)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.smokevirt
+def test_smokevirt_factory_reset(firmware_node):
+    """--set factory_reset true returns rc=0.
+
+    We only assert the CLI command succeeds. The node's persistent state is
+    wiped by the reset and the sandboxed sim process may exit shortly
+    after; the function-scoped fixture teardown handles cleaning up the
+    (likely-dead) meshtasticd process.
     """
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --set-ham KI1234"
-    )
-    assert re.search(r"Setting Ham ID", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_REBOOT)
-    return_value, out = subprocess.getstatusoutput("$MESHTASTIC_CLI --host localhost:$VIRT_PORT --info")
-    assert re.search(r"Owner: KI1234", out, re.MULTILINE)
-    assert return_value == 0
-
-
-@pytest.mark.xfail(reason="assertions need updating for current CLI output format", strict=False)
-@pytest.mark.smokevirt
-def test_smokevirt_set_wifi_settings():
-    """Test --set wifi_ssid and --set wifi_password"""
-    return_value, out = subprocess.getstatusoutput(
-        '$MESHTASTIC_CLI --host localhost:$VIRT_PORT --set wifi_ssid "some_ssid" --set wifi_password "temp1234"'
-    )
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"^Set wifi_ssid to some_ssid", out, re.MULTILINE)
-    assert re.search(r"^Set wifi_password to temp1234", out, re.MULTILINE)
-    assert return_value == 0
-    # pause for the radio
-    time.sleep(PAUSE_AFTER_COMMAND)
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --get wifi_ssid --get wifi_password"
-    )
-    assert re.search(r"^wifi_ssid: some_ssid", out, re.MULTILINE)
-    assert re.search(r"^wifi_password: sekrit", out, re.MULTILINE)
-    assert return_value == 0
-
-
-@pytest.mark.smokevirt
-@pytest.mark.skip(reason="factory_reset destroys the session node's config; needs per-test node restart")
-def test_smokevirt_factory_reset():
-    """Test factory reset"""
-    return_value, out = subprocess.getstatusoutput(
-        "$MESHTASTIC_CLI --host localhost:$VIRT_PORT --set factory_reset true"
-    )
-    assert re.search(r"Connected to radio", out)
-    assert re.search(r"^Set factory_reset to true", out, re.MULTILINE)
-    assert re.search(r"^Writing modified preferences to device", out, re.MULTILINE)
-    assert return_value == 0
-    # NOTE: The virtual radio will not respond well after this command. Need to re-start the virtual program at this point.
-    # TODO: fix?
+    rc, out = run_cli(firmware_node.port, "--set", "factory_reset", "true")
+    assert rc == 0, out
+    # The CLI prints a confirmation line before the firmware actually resets.
+    assert re.search(r"(?i)factory.?reset|writing", out), out

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 
-addopts = -m "not int and not smoke1 and not smoke2 and not smokewifi and not examples and not smokevirt"
+addopts = -m "not int and not smoke1 and not smoke2 and not smokewifi and not examples and not smokevirt and not smokemesh"
 
 filterwarnings =
     ignore::DeprecationWarning
@@ -13,4 +13,5 @@ markers =
     smoke1: runs smoke tests on a single device connected via USB
     smoke2: runs smoke tests on a two devices connected via USB
     smokewifi: runs smoke test on an esp32 device setup with wifi
+    smokemesh: runs smoke tests against multiple meshtasticd sim instances
     examples: runs the examples tests which validates the library


### PR DESCRIPTION
When merged this should fix #643 as well. Still adding a bit of stuff to make `smokevirt` not so useless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LoRa modem preset CLI options for channel switching, including long/turbo variants (with an alias for long-moderate).
* **Bug Fixes**
  * Optimized channel deletion to write only the channel slots whose serialized content actually changes.
* **Tests**
  * Added a full simulator-based firmware test harness and helpers; introduced multi-node “smokemesh” tests and refactored “smokevirt” to assert persisted state via the library.
* **Chores**
  * Updated CI to broaden Python version coverage and added simulator smoke runs across multiple release channels; adjusted pytest markers and firmware test skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->