### PR TITLE
Half-close TCP connections so the last write is not lost

### DIFF
--- a/meshtastic/tcp_interface.py
+++ b/meshtastic/tcp_interface.py
@@ -11,6 +11,11 @@ from typing import Optional
 from meshtastic.stream_interface import StreamInterface
 
 DEFAULT_TCP_PORT = 4403
+
+# How long close() gives the device to consume what we last wrote before forcing
+# the connection down. See close() for why this exists.
+GRACEFUL_CLOSE_TIMEOUT = 0.25
+
 logger = logging.getLogger(__name__)
 
 
@@ -80,6 +85,18 @@ class TCPInterface(StreamInterface):
         server_address = (self.hostname, self.portNumber)
         self.socket = socket.create_connection(server_address)
 
+    def _wait_for_reader_exit(self, timeout: float) -> None:
+        """Wait briefly for the reader thread to drain and exit after a half-close.
+
+        Returns as soon as it exits, or after timeout: the device is not obliged
+        to close just because we did.
+        """
+        rx = getattr(self, "_rxThread", None)
+        if rx is None or rx is threading.current_thread():
+            return
+        with contextlib.suppress(Exception):
+            rx.join(timeout)
+
     def close(self) -> None:
         """Close a connection to the device."""
         logger.debug("Closing TCP stream")
@@ -87,6 +104,20 @@ class TCPInterface(StreamInterface):
         # Therefore force a shutdown first to unblock reader thread reads.
         self._wantExit = True
         if self.socket is not None:
+            # Half-close first. shutdown(SHUT_WR) sends FIN, which tells the
+            # device we are done writing and lets it consume what we last wrote
+            # before the connection goes away -- typically the admin message a
+            # one-shot command such as `--set` just sent.
+            #
+            # Going straight to shutdown(SHUT_RDWR) + close() while either side
+            # still has unread data makes the stack send RST instead. Winsock
+            # then discards data the peer had already received but not yet read,
+            # so the write is lost; Linux delivers it before reporting
+            # ECONNRESET, which is why this only bites on Windows.
+            with contextlib.suppress(Exception):
+                self.socket.shutdown(socket.SHUT_WR)
+            self._wait_for_reader_exit(GRACEFUL_CLOSE_TIMEOUT)
+
             with contextlib.suppress(
                 Exception
             ):  # Ignore errors in shutdown, because we might have a race with the server

--- a/meshtastic/tests/test_tcp_interface.py
+++ b/meshtastic/tests/test_tcp_interface.py
@@ -1,6 +1,7 @@
 """Meshtastic unit tests for tcp_interface.py"""
 
 import re
+import socket
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -74,6 +75,56 @@ def test_TCPInterface_close_shutdowns_socket_before_super_close():
             iface.close()
 
     assert call_order == ["shutdown", "super_close"]
+    sock.close.assert_called_once()
+    assert iface.socket is None
+
+
+@pytest.mark.unit
+def test_TCPInterface_close_half_closes_before_shutdown():
+    """Close should send FIN and let the device drain before forcing the link down.
+
+    Going straight to shutdown(SHUT_RDWR)/close() with data still unread makes the
+    stack send RST, and Winsock then discards data the device had received but not
+    yet read, silently losing writes such as `--set`.
+    """
+    iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)
+    sock = MagicMock()
+    iface.socket = sock
+    call_order = []
+
+    with patch.object(TCPInterface, "_socket_shutdown", autospec=True) as mock_shutdown:
+        with patch.object(
+            TCPInterface, "_wait_for_reader_exit", autospec=True
+        ) as mock_wait:
+            with patch(
+                "meshtastic.stream_interface.StreamInterface.close", autospec=True
+            ) as mock_super_close:
+                sock.shutdown.side_effect = lambda how: call_order.append(f"shutdown_{how}")
+                mock_wait.side_effect = lambda _self, _t: call_order.append("wait")
+                mock_shutdown.side_effect = lambda _self: call_order.append("full_shutdown")
+                mock_super_close.side_effect = lambda _self: call_order.append("super_close")
+
+                iface.close()
+
+    assert call_order == [
+        f"shutdown_{socket.SHUT_WR}",
+        "wait",
+        "full_shutdown",
+        "super_close",
+    ]
+
+
+@pytest.mark.unit
+def test_TCPInterface_close_survives_half_close_failure():
+    """A peer that already vanished must not break close()."""
+    iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)
+    sock = MagicMock()
+    sock.shutdown.side_effect = OSError("already gone")
+    iface.socket = sock
+
+    with patch("meshtastic.stream_interface.StreamInterface.close", autospec=True):
+        iface.close()  # must not raise
+
     sock.close.assert_called_once()
     assert iface.socket is None
 


### PR DESCRIPTION
Fixes #957.

One-shot config writes over TCP are silently lost on Windows: `--set` reports
success and the device never applies it. Reads are unaffected.

## Cause

`close()` went straight to `shutdown(SHUT_RDWR)` + `close()`. Doing that while
either side still has unread data makes the stack send **RST** rather than FIN,
and the device's FromRadio stream means there is essentially always unread data.

**Winsock discards data that was received but not yet read when an RST arrives**,
so the admin message written moments earlier is thrown away before the device gets
to read it. Linux delivers the buffered bytes before reporting `ECONNRESET`, which
is why this only surfaced on Windows.

`writeConfig()` does not wait for an ack, so `close()` runs microseconds after
`sendall()`.

## Fix

Send FIN first via `shutdown(SHUT_WR)`, so the device can consume what we wrote,
wait briefly for the reader thread to drain and exit, then tear down exactly as
before.

The existing `shutdown(SHUT_RDWR)` is deliberately kept: it unblocks a reader
still sitting in `recv()` so `StreamInterface.close()` can join it. The added wait
is bounded (`GRACEFUL_CLOSE_TIMEOUT`, 0.25s) and returns early when the reader
exits, because a device is not obliged to close just because we half-closed.

## Why not fix it device-side

It is a race with a tiny window, and the device already loses it. Bisecting the
linger between `writeConfig()` and `close()`, same device and command:

| linger | result |
|---|---|
| 0s (current behaviour) | region `UNSET` - lost |
| 0.05s | region applied |
| 0.2s / 10s | region applied |

50ms suffices. meshtasticd polls its socket every 5ms and drains in a loop, so it
is not slow - the RST simply beats its next read. Nothing on the device can read
faster than the gap between the client's `send()` and its `close()`.

## Testing

* `pytest meshtastic/tests/test_tcp_interface.py` - 9 passed.
* Two new unit tests: one asserts the half-close/wait/full-shutdown ordering, one
  asserts `close()` survives a peer that has already vanished. The ordering test
  **fails** if `close()` is reverted to its previous behaviour, so it pins the
  regression rather than just describing it.
* End-to-end against a real device (meshtasticd, Windows 11, Python 3.12), same
  command both times:
  * stock CLI: `lora.region : 0 (UNSET)` - lost
  * patched: `lora.region : 1 (US)` - applied

Behaviour on Linux/macOS is unchanged apart from up to 0.25s of extra latency on
close, and less of it in practice since the wait ends as soon as the reader exits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP connection shutdown to close gracefully before forcing termination.
  * Added a brief wait for active reader processes to exit cleanly.
  * Improved resilience when the remote connection is already unavailable, ensuring sockets still close without errors.

* **Tests**
  * Added coverage for graceful shutdown ordering and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->