### PR TITLE
Skip node DB fetch during --ota-update / --reboot-ota

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1590,6 +1590,12 @@ def common():
             if not os.path.isfile(args.ota_update):
                 meshtastic.util.our_exit(f"Error: OTA firmware file not found: {args.ota_update}", 1)
 
+        # OTA (WiFi/BLE) only needs the local node to send the admin request and then
+        # streams the firmware directly; it never reads the node DB. Skip fetching it so a
+        # large node DB dump can't stall/close the connection before the OTA request lands.
+        if getattr(args, "ota_update", None) or getattr(args, "reboot_ota", False):
+            args.no_nodes = True
+
         if have_powermon:
             create_power_meter()
 


### PR DESCRIPTION
## Problem

`meshtastic --host <ip> --ota-update firmware.bin` can silently fail to start the OTA on devices with a large node DB. The device never enters OTA mode (the WiFi OTA loader on `:3232` never comes up) and the client ends with `Connection refused`.

## Root cause

The OTA flow only needs the **local** node — to send the `startOTA` admin request — and then streams the firmware directly to the OTA loader over WiFi. It never reads the node DB. But the CLI still fetches the full node DB on connect.

On a device with a large node DB (e.g. ~250 nodes on an ESP32-S3 in a busy public mesh), that dump stalls and the firmware closes the API connection before it processes the OTA request:

```
[ServerAPI] TCP client write short (0/61 bytes), closing API service
```

So `startOTA` is never handled, the device doesn't reboot into the OTA loader, and `--ota-update` fails. Passing `--no-nodes` manually works around it.

## Fix

Imply `--no-nodes` when `--ota-update` or `--reboot-ota` is used, since neither reads the node DB. No effect on other commands.

## Verification

On a T-Beam 1W (ESP32-S3, ~250-node DB) with the unified WiFi OTA loader installed:

- **Before:** `meshtastic --host <ip> --ota-update fw.bin` → `Connection refused`; device log shows `TCP client write short (0/61 bytes), closing API service` and no `OTA Requested`.
- **After (no `--no-nodes` needed):** `meshtastic --host <ip> --ota-update fw.bin` → `OTA update completed successfully!`; device log shows `OTA Requested → OTA partition contains combined BLE/WiFi OTA Loader → Rebooting to WiFi OTA → Listening on TCP port 3232`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTA updates and reboot-to-OTA commands by preventing unnecessary node database loading.
  * OTA-related requests now start more reliably without unwanted startup output or interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->