### PR TITLE
Replace bare except clauses with specific exception types

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -1348,7 +1348,7 @@ class MeshInterface:  # pylint: disable=R0902
             try:
                 newpos = self._fixupPosition(node["position"])
                 node["position"] = newpos
-            except:
+            except (KeyError, TypeError):
                 logger.debug("Node without position")
 
             # no longer necessary since we're mutating directly in nodesByNum via _getOrCreateByNum
@@ -1516,7 +1516,7 @@ class MeshInterface:  # pylint: disable=R0902
 
         try:
             return self.nodesByNum[num]["user"]["id"]  # type: ignore[index]
-        except:
+        except (KeyError, TypeError):
             logger.debug(f"Node {num} not found for fromId")
             return None
 

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -161,7 +161,7 @@ class StreamInterface(MeshInterface):
         utf = "?"  # assume we might fail
         try:
             utf = b.decode("utf-8")
-        except:
+        except UnicodeDecodeError:
             pass
 
         if utf == "\r":

--- a/meshtastic/test.py
+++ b/meshtastic/test.py
@@ -205,7 +205,7 @@ def testSimulator() -> None:
         iface.localNode.exitSimulator()
         iface.close()
         logger.info("Integration test successful!")
-    except:
+    except Exception:
         print("Error while testing simulator:", sys.exc_info()[0])
         traceback.print_exc()
         sys.exit(1)

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -309,7 +309,7 @@ class DeferredExecution:
             try:
                 o = self.queue.get()
                 o()
-            except:
+            except Exception:
                 logger.error(
                     f"Unexpected error in deferred execution {sys.exc_info()[0]}"
                 )
@@ -360,7 +360,7 @@ def remove_keys_from_dict(keys: Union[Tuple, List, Set], adict: Dict) -> Dict:
     for key in keys:
         try:
             del adict[key]
-        except:
+        except KeyError:
             pass
     for val in adict.values():
         if isinstance(val, dict):

--- a/meshtastic/version.py
+++ b/meshtastic/version.py
@@ -2,7 +2,7 @@
 import sys
 try:
     from importlib.metadata import version
-except:
+except ImportError:
     import pkg_resources
 
 def get_active_version():


### PR DESCRIPTION
Bare except: catches BaseException, which includes KeyboardInterrupt and SystemExit. This prevents clean Ctrl-C shutdown and can swallow sys.exit() calls. Each clause is narrowed to the specific exception the try block can actually raise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across mesh communication, device logging, deferred operations, and version detection.
  * Expected missing data, invalid values, decoding issues, and unavailable imports continue to be handled safely.
  * Unexpected errors are now surfaced instead of being silently suppressed, improving reliability and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->